### PR TITLE
Implement 8-bit Styled OTP Input Component

### DIFF
--- a/app/docs/components/input-otp/page.tsx
+++ b/app/docs/components/input-otp/page.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { Input } from "@/components/ui/8bit/input"
 import {
   InputOTP,
   InputOTPGroup,

--- a/app/docs/components/input-otp/page.tsx
+++ b/app/docs/components/input-otp/page.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { Input } from "@/components/ui/8bit/input"
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "@/components/ui/8bit/input-otp"
+import { Separator } from "@/components/ui/separator"
+
+import CodeSnippet from "../code-snippet"
+import CopyCommandButton from "../copy-command-button"
+import InstallationCommands from "../installation-commands"
+import { OpenInV0Button } from "../open-in-v0-button"
+
+const InputOTPPage = () => {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col md:flex-row items-center justify-between gap-2">
+        <h1 className="text-3xl font-bold">8-bit OTP Input</h1>
+        <CopyCommandButton
+          copyCommand={`pnpm dlx shadcn@canary add ${process.env.NEXT_PUBLIC_BASE_URL}/r/8bit-input.json`}
+          command={"pnpm dlx shadcn@canary add 8bit-input"}
+        />
+      </div>
+
+      <p className="text-muted-foreground">
+        Displays a retro 8-bit style OTP input.
+      </p>
+
+      <div className="flex flex-col gap-4 border rounded-lg p-4 min-h-[450px] relative">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm text-muted-foreground sm:pl-3">
+            A simple 8-bit OTP input component
+          </h2>
+
+          <div className="flex items-center gap-2">
+            <OpenInV0Button name="8bit-input" className="w-fit" />
+          </div>
+        </div>
+        <div className="flex items-center justify-center min-h-[400px] max-w-md mx-auto relative">
+          <InputOTP maxLength={6}>
+            <InputOTPGroup>
+              <InputOTPSlot index={0} />
+              <InputOTPSlot index={1} />
+              <InputOTPSlot index={2} />
+            </InputOTPGroup>
+            <InputOTPSeparator />
+            <InputOTPGroup>
+              <InputOTPSlot index={3} />
+              <InputOTPSlot index={4} />
+              <InputOTPSlot index={5} />
+            </InputOTPGroup>
+          </InputOTP>
+        </div>
+      </div>
+
+      <h3 className="text-lg font-bold">Installation</h3>
+
+      <Separator />
+
+      <InstallationCommands
+        packageUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/r/8bit-input.json`}
+      />
+
+      <h3 className="text-lg font-bold mt-10">Usage</h3>
+
+      <Separator />
+
+      <CodeSnippet>{`import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+  InputOTPSeparator
+} from "@/components/ui/8bit/input-otp"`}</CodeSnippet>
+
+      <CodeSnippet>{`<InputOTP maxLength={6}>
+  <InputOTPGroup>
+    <InputOTPSlot index={0} />
+    <InputOTPSlot index={1} />
+    <InputOTPSlot index={2} />
+  </InputOTPGroup>
+  <InputOTPSeparator />
+  <InputOTPGroup>
+    <InputOTPSlot index={3} />
+    <InputOTPSlot index={4} />
+    <InputOTPSlot index={5} />
+  </InputOTPGroup>
+</InputOTP>`}</CodeSnippet>
+    </div>
+  )
+}
+
+export default InputOTPPage

--- a/components/ui/8bit/input-otp.tsx
+++ b/components/ui/8bit/input-otp.tsx
@@ -1,0 +1,83 @@
+import { Press_Start_2P } from "next/font/google"
+import { cva, VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import {
+  InputOTP as ShadcnInputOTP,
+  InputOTPGroup as ShadcnInputOTPGroup,
+  InputOTPSeparator as ShadcnInputOTPSeparator,
+  InputOTPSlot as ShadcnInputOTPSlot,
+} from "@/components/ui/input-otp"
+
+const pressStart = Press_Start_2P({
+  weight: ["400"],
+  subsets: ["latin"],
+})
+
+export const inputVariants = cva("", {
+  variants: {
+    font: {
+      normal: "",
+      retro: pressStart.className,
+    },
+  },
+  defaultVariants: {
+    font: "retro",
+  },
+})
+
+interface SharedProps
+  extends React.HTMLAttributes<HTMLElement>,
+    VariantProps<typeof inputVariants> {
+  className?: string
+  children?: React.ReactNode
+}
+
+export const InputOTP = ({ className, font, ...props }: SharedProps) => {
+  return (
+    <div className={cn("relative w-fit", className)}>
+      <ShadcnInputOTP
+        {...props}
+        className={cn(font !== "normal" && pressStart.className, className)}
+      />
+    </div>
+  )
+}
+
+export const InputOTPGroup = ({ className, ...props }: SharedProps) => {
+  return (
+    <ShadcnInputOTPGroup {...props} className={cn("flex gap-2", className)} />
+  )
+}
+
+export const InputOTPSlot = ({
+  className,
+  font,
+  index,
+  ...props
+}: SharedProps & { index?: number }) => {
+  return (
+    <div className="relative w-12 h-12">
+      <ShadcnInputOTPSlot
+        index={index}
+        {...props}
+        className={cn(
+          "w-full h-full text-center text-xl tracking-widest caret-transparent border-none bg-background",
+          font !== "normal" && pressStart.className,
+          className
+        )}
+      />
+      {/* 8-bit border */}
+      <div className="absolute top-0 left-0 w-full h-1.5 bg-foreground dark:bg-ring pointer-events-none" />
+      <div className="absolute bottom-0 w-full h-1.5 bg-foreground dark:bg-ring pointer-events-none" />
+      <div className="absolute top-1 -left-1 w-1.5 h-1/2 bg-foreground dark:bg-ring pointer-events-none" />
+      <div className="absolute bottom-1 -left-1 w-1.5 h-1/2 bg-foreground dark:bg-ring pointer-events-none" />
+      <div className="absolute top-1 -right-1 w-1.5 h-1/2 bg-foreground dark:bg-ring pointer-events-none" />
+      <div className="absolute bottom-1 -right-1 w-1.5 h-1/2 bg-foreground dark:bg-ring pointer-events-none" />
+    </div>
+  )
+}
+
+export const InputOTPSeparator = ({ className, ...props }: SharedProps) => {
+  return <ShadcnInputOTPSeparator {...props} className={cn("", className)} />
+}

--- a/components/ui/input-otp.tsx
+++ b/components/ui/input-otp.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import * as React from "react"
+import { OTPInput, OTPInputContext } from "input-otp"
+import { MinusIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function InputOTP({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<typeof OTPInput> & {
+  containerClassName?: string
+}) {
+  return (
+    <OTPInput
+      data-slot="input-otp"
+      containerClassName={cn(
+        "flex items-center gap-2 has-disabled:opacity-50",
+        containerClassName
+      )}
+      className={cn("disabled:cursor-not-allowed", className)}
+      {...props}
+    />
+  )
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn("flex items-center", className)}
+      {...props}
+    />
+  )
+}
+
+function InputOTPSlot({
+  index,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  index: number
+}) {
+  const inputOTPContext = React.useContext(OTPInputContext)
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
+
+  return (
+    <div
+      data-slot="input-otp-slot"
+      data-active={isActive}
+      className={cn(
+        "data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]",
+        className
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="animate-caret-blink bg-foreground h-4 w-px duration-1000" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
+  return (
+    <div data-slot="input-otp-separator" role="separator" {...props}>
+      <MinusIcon size={32} strokeWidth={5} color="oklch(0.554 0.135 66.442)" />
+    </div>
+  )
+}
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/config/nav-items.ts
+++ b/config/nav-items.ts
@@ -71,6 +71,11 @@ export const navItems = {
           url: "/docs/components/input",
         },
         {
+          title: "Input OTP",
+          url: "/docs/components/input-otp",
+          new: true,
+        },
+        {
           title: "Select",
           url: "/docs/components/select",
         },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "input-otp": "^1.4.2",
     "lucide-react": "^0.487.0",
     "next": "15.3.0",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      input-otp:
+        specifier: ^1.4.2
+        version: 1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       lucide-react:
         specifier: ^0.487.0
         version: 0.487.0(react@19.1.0)
@@ -2098,6 +2101,12 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  input-otp@1.4.2:
+    resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -5298,6 +5307,11 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
+
+  input-otp@1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   internal-slot@1.1.0:
     dependencies:

--- a/registry.json
+++ b/registry.json
@@ -32,6 +32,20 @@
       ]
     },
     {
+      "name": "8bit-input-otp",
+      "type": "registry:component",
+      "title": "8-bit Input-OTP",
+      "description": "A simple 8-bit input-otp component",
+      "registryDependencies": ["input-otp"],
+      "files": [
+        {
+          "path": "components/ui/8bit/input-otp.tsx",
+          "type": "registry:component",
+          "target": "components/ui/8bit/input-otp.tsx"
+        }
+      ]
+    },
+    {
       "name": "8bit-badge",
       "type": "registry:component",
       "title": "8-bit Badge",


### PR DESCRIPTION
This PR introduces an 8-bit styled OTP input component that brings a retro, pixelated aesthetic to OTP inputs. The following updates were made:
![Screenshot from 2025-04-14 17-25-27](https://github.com/user-attachments/assets/270ced3d-4cac-4270-a0b3-79506f56a8fc)

Component Addition:
- InputOTP: A container component for OTP input with retro styling.

- InputOTPGroup: Groups OTP input slots together.

- InputOTPSlot: Individual slots for OTP digits with 8-bit border effects.

- InputOTPSeparator: Provides a separator between OTP groups.

Styling:
- Integrated Press Start 2P font to achieve a retro, 8-bit look for the input components.

- Each OTP slot has a distinct 8-bit styled border, adding to the pixelated theme.
- 
Page:
- Created a dedicated InputOTPPage to demonstrate how to use the new 8-bit OTP input components.
- Added installation and usage code examples with interactive buttons for copying commands and opening the component in the V0 environment.

