### PR TITLE
chore(next.config): remove remote image pattern for Twitter from Next…

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "pbs.twimg.com",
-      },
-    ],
-  },
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
….js configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified image handling configuration by removing the predefined allowlist for remote image hosts.
  * Impact: Display and optimization of some externally hosted images may change. Images from previously allowed domains might not render or be optimized until configuration is updated. Local images are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->