### PR TITLE
fix(registry) add progress bar dependency for the health bar

### DIFF
--- a/public/r/health-bar.json
+++ b/public/r/health-bar.json
@@ -4,7 +4,9 @@
   "type": "registry:component",
   "title": "8-bit Health Bar",
   "description": "A simple 8-bit health bar component",
-  "registryDependencies": [],
+  "registryDependencies": [
+    "progress"
+  ],
   "files": [
     {
       "path": "components/ui/8bit/health-bar.tsx",

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -612,7 +612,7 @@
       "type": "registry:component",
       "title": "8-bit Health Bar",
       "description": "A simple 8-bit health bar component",
-      "registryDependencies": [],
+      "registryDependencies": ["progress"],
       "files": [
         {
           "path": "components/ui/8bit/health-bar.tsx",

--- a/registry.json
+++ b/registry.json
@@ -612,7 +612,7 @@
       "type": "registry:component",
       "title": "8-bit Health Bar",
       "description": "A simple 8-bit health bar component",
-      "registryDependencies": [],
+      "registryDependencies": ["progress"],
       "files": [
         {
           "path": "components/ui/8bit/health-bar.tsx",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Declare the "progress" component as a registry dependency for the 8-bit Health Bar so it installs together and renders correctly. Updated health-bar.json and both registry index files to include "progress".

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Declared an explicit dependency: the 8-bit Health Bar component now depends on the Progress component in the registry. This aligns metadata with existing files and ensures the Progress component is included automatically when using Health Bar.
  - No functional or visual changes for end-users; behavior remains the same.
  - No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->