### PR TITLE
fix(dropdown-menu): add optional inset and variant props to DropdownMenuItem

### DIFF
--- a/components/ui/8bit/dropdown-menu.tsx
+++ b/components/ui/8bit/dropdown-menu.tsx
@@ -61,7 +61,10 @@ function DropdownMenuItem({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
   return (
     <ShadcnDropdownMenuItem
       className={cn(


### PR DESCRIPTION
The `DropdownMenuPrimitive.Item` component type does not include the `variant` and `inset` props by default.  
These props were added in the Shadcn implementation by extending the base props type.  

This PR adds `variant` and `inset` to the 8bit implementation using the same approach.

Closes #382 