### PR TITLE
refactor(data-table): simplify status display and remove unnecessary …

### DIFF
--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -129,7 +129,6 @@ function DragHandle({ id }: { id: number }) {
       {...attributes}
       {...listeners}
       variant="ghost"
-      size="icon"
       className="text-muted-foreground size-7 hover:bg-transparent"
     >
       <IconGripVertical className="text-muted-foreground size-3" />
@@ -190,16 +189,7 @@ const columns: ColumnDef<z.infer<typeof schema>>[] = [
   {
     accessorKey: "status",
     header: "Status",
-    cell: ({ row }) => (
-      <Badge>
-        {row.original.status === "Done" ? (
-          <IconCircleCheckFilled className="fill-green-500 dark:fill-green-400" />
-        ) : (
-          <IconLoader />
-        )}
-        {row.original.status}
-      </Badge>
-    ),
+    cell: ({ row }) => <Badge>{row.original.status}</Badge>,
   },
   {
     accessorKey: "target",
@@ -421,13 +411,13 @@ export function DataTable({
           </SelectContent>
         </Select>
 
-        <TabsList className="**:data-[slot=badge]:bg-muted-foreground/30 hidden **:data-[slot=badge]:size-5 **:data-[slot=badge]:rounded-full **:data-[slot=badge]:px-1 @4xl/main:flex">
+        <TabsList className="hidden **:data-[slot=badge]:size-5 **:data-[slot=badge]:px-1 @4xl/main:flex">
           <TabsTrigger value="outline">Outline</TabsTrigger>
           <TabsTrigger value="past-performance">
-            Past Performance <Badge variant="secondary">3</Badge>
+            Past Performance <Badge>3</Badge>
           </TabsTrigger>
           <TabsTrigger value="key-personnel">
-            Key Personnel <Badge variant="secondary">2</Badge>
+            Key Personnel <Badge>2</Badge>
           </TabsTrigger>
         </TabsList>
 
@@ -435,7 +425,6 @@ export function DataTable({
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm">
-                <IconLayoutColumns />
                 <span className="hidden lg:inline">Customize Columns</span>
                 <span className="lg:hidden">Columns</span>
                 <IconChevronDown />
@@ -466,7 +455,6 @@ export function DataTable({
             </DropdownMenuContent>
           </DropdownMenu>
           <Button variant="outline" size="sm">
-            <IconPlus />
             <span className="hidden lg:inline">Add Section</span>
           </Button>
         </div>
@@ -610,16 +598,16 @@ export function DataTable({
         value="past-performance"
         className="flex flex-col px-4 lg:px-6"
       >
-        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
+        <div className="aspect-video w-full flex-1 border border-dashed"></div>
       </TabsContent>
       <TabsContent value="key-personnel" className="flex flex-col px-4 lg:px-6">
-        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
+        <div className="aspect-video w-full flex-1 border border-dashed"></div>
       </TabsContent>
       <TabsContent
         value="focus-documents"
         className="flex flex-col px-4 lg:px-6"
       >
-        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
+        <div className="aspect-video w-full flex-1 border border-dashed"></div>
       </TabsContent>
     </Tabs>
   );


### PR DESCRIPTION
…props for improved clarity
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Simplified the DataTable UI by showing status as a plain badge and removing unnecessary props and icons. This reduces visual noise and makes the table easier to scan.

- **Refactors**
  - Status column now uses a text-only Badge; removed conditional status icons.
  - Simplified Tabs badges by using default Badge and cleaned TabsList classes.
  - Removed extraneous icons from “Customize Columns” and “Add Section” buttons.
  - Dropped the size prop from the drag handle; rely on existing classes.
  - Minor layout cleanups on placeholder panels (remove extra rounding).

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Streamlined table and tab visuals by replacing dashed/rounded elements with standard borders.
  - Simplified status display to a single badge, removing loading/check icons.
  - Removed decorative icons from toolbar actions for a cleaner look.
  - Unified badge styling across tabs for consistency.

- Refactor
  - Simplified class names and removed unused slot-based styling.
  - Adjusted drag handle button sizing for consistent appearance across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->