### PR TITLE
fix(nav-items): update href for Blocks navigation item to point to fe…

### DIFF
--- a/config/nav-items.ts
+++ b/config/nav-items.ts
@@ -216,7 +216,7 @@ export const navItems = {
     },
     {
       label: "Blocks",
-      href: "/blocks/authentication",
+      href: "/blocks/featured",
     },
     {
       label: "Themes",


### PR DESCRIPTION
…atured section
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the "Blocks" nav item to link to /blocks/featured instead of /blocks/authentication, so users go to the Featured section as intended.

<!-- End of auto-generated description by cubic. -->

