### PR TITLE
fix(dashboard) add dependencies for dashboard

### DIFF
--- a/public/r/dashboard-01.json
+++ b/public/r/dashboard-01.json
@@ -4,6 +4,16 @@
   "type": "registry:component",
   "title": "8-bit Dashboard 01",
   "description": "A complete 8-bit styled dashboard with sidebar navigation, stats cards, charts, and data table with drag-and-drop functionality.",
+  "dependencies": [
+    "@dnd-kit/core",
+    "@dnd-kit/sortable",
+    "@dnd-kit/modifiers",
+    "@dnd-kit/utilities",
+    "@tabler/icons-react",
+    "@tanstack/react-table",
+    "sonner",
+    "zod"
+  ],
   "registryDependencies": [
     "sidebar",
     "button",
@@ -19,15 +29,7 @@
     "select",
     "separator",
     "table",
-    "tabs",
-    "@dnd-kit/core",
-    "@dnd-kit/sortable",
-    "@dnd-kit/modifiers",
-    "@dnd-kit/utilities",
-    "@tabler/icons-react",
-    "@tanstack/react-table",
-    "sonner",
-    "zod"
+    "tabs"
   ],
   "files": [
     {

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -1596,7 +1596,9 @@
         "select",
         "separator",
         "table",
-        "tabs",
+        "tabs"
+      ],
+      "dependencies": [
         "@dnd-kit/core",
         "@dnd-kit/sortable",
         "@dnd-kit/modifiers",

--- a/registry.json
+++ b/registry.json
@@ -1596,7 +1596,9 @@
         "select",
         "separator",
         "table",
-        "tabs",
+        "tabs"
+      ],
+      "dependencies": [
         "@dnd-kit/core",
         "@dnd-kit/sortable",
         "@dnd-kit/modifiers",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added explicit dependencies for the 8-bit Dashboard 01 component and moved them out of registryDependencies. This ensures required packages are installed and prevents runtime errors for drag-and-drop, icons, tables, toasts, and validation.

<!-- End of auto-generated description by cubic. -->

