### PR TITLE
fix(dashboard-header): remove unnecessary padding from header component

### DIFF
--- a/components/dashboard-header.tsx
+++ b/components/dashboard-header.tsx
@@ -10,7 +10,7 @@ export function DashboardHeader() {
 
   return (
     <header className="flex sticky top-0 z-50 h-14 shrink-0 items-center gap-2 border-b-4 border-foreground dark:border-ring bg-background/95">
-      <div className="flex w-full items-center h-full gap-4 px-4 md:px-6">
+      <div className="flex w-full items-center h-full gap-4">
         <Button variant="ghost" onClick={toggleSidebar}>
           {open ? (
             <svg


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed unnecessary horizontal padding from the DashboardHeader content wrapper to fix misalignment. Header items now align flush and spacing is consistent on all screen sizes.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Dashboard header layout by removing responsive horizontal padding, creating a cleaner, edge-to-edge alignment across all screen sizes.
  * Improves visual consistency with surrounding content and slightly increases usable space in the header area.
  * Spacing between header elements is preserved for readability; no interactive behavior or functionality is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->