### PR TITLE
fix(dashboard-header): add right padding to header component for impr…

### DIFF
--- a/components/dashboard-header.tsx
+++ b/components/dashboard-header.tsx
@@ -10,7 +10,7 @@ export function DashboardHeader() {
 
   return (
     <header className="flex sticky top-0 z-50 h-14 shrink-0 items-center gap-2 border-b-4 border-foreground dark:border-ring bg-background/95">
-      <div className="flex w-full items-center h-full gap-4">
+      <div className="flex w-full items-center h-full gap-4 pr-4 md:pr-6">
         <Button variant="ghost" onClick={toggleSidebar}>
           {open ? (
             <svg


### PR DESCRIPTION
…oved layout
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added right padding to the dashboard header container to prevent content from touching the right edge and improve spacing. Uses pr-4 on small screens and md:pr-6 on medium and up.

<!-- End of auto-generated description by cubic. -->

