### PR TITLE
feat(code-snippet): implement custom theme for code highlighting with…

### DIFF
--- a/app/docs/components/code-snippet.tsx
+++ b/app/docs/components/code-snippet.tsx
@@ -11,9 +11,85 @@ import { toast } from "@/components/ui/8bit/toast";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
-function countLines(code: string) {
-  return code.split("\n").length;
-}
+// Custom theme that uses CSS variables from the current theme
+const createCustomTheme = () => ({
+  name: "custom-theme",
+  type: "dark" as const,
+  colors: {
+    "editor.background": "var(--background)",
+    "editor.foreground": "var(--foreground)",
+  },
+  tokenColors: [
+    {
+      scope: ["comment", "punctuation.definition.comment"],
+      settings: {
+        foreground: "var(--muted-foreground)",
+        fontStyle: "italic",
+      },
+    },
+    {
+      scope: ["string", "string.quoted"],
+      settings: {
+        foreground: "var(--foreground)",
+      },
+    },
+    {
+      scope: [
+        "keyword",
+        "keyword.control",
+        "keyword.operator",
+        "keyword.other",
+      ],
+      settings: {
+        foreground: "var(--primary)",
+        fontStyle: "bold",
+      },
+    },
+    {
+      scope: ["variable", "variable.other", "variable.parameter"],
+      settings: {
+        foreground: "var(--foreground)",
+      },
+    },
+    {
+      scope: ["entity.name.function", "support.function"],
+      settings: {
+        foreground: "var(--chart-3)",
+      },
+    },
+    {
+      scope: ["constant", "constant.numeric", "constant.language"],
+      settings: {
+        foreground: "var(--chart-4)",
+      },
+    },
+    {
+      scope: ["entity.name.type", "entity.name.class"],
+      settings: {
+        foreground: "var(--chart-5)",
+        fontStyle: "bold",
+      },
+    },
+    {
+      scope: ["punctuation", "punctuation.separator", "punctuation.terminator"],
+      settings: {
+        foreground: "var(--muted-foreground)",
+      },
+    },
+    {
+      scope: ["meta.brace", "punctuation.section.brackets"],
+      settings: {
+        foreground: "var(--border)",
+      },
+    },
+    {
+      scope: ["text", "source"],
+      settings: {
+        foreground: "var(--foreground)",
+      },
+    },
+  ],
+});
 
 export default function CodeSnippet({
   children,
@@ -33,18 +109,19 @@ export default function CodeSnippet({
     toast("Copied to clipboard");
   };
 
+  const customTheme = createCustomTheme();
+
   return (
-    <ScrollArea className={cn("relative overflow-x-auto h-max max-w-full")}>
+    <ScrollArea
+      className={cn("relative overflow-x-auto h-max max-w-full border")}
+    >
       <ShikiHighlighter
         addDefaultStyles={false}
         language="jsx"
         showLanguage={false}
-        theme={{
-          light: "laserwave",
-          dark: "laserwave",
-        }}
+        theme={customTheme}
         as="div"
-        className="w-full text-sm [&>pre]:p-4 [&>pre]:overflow-x-auto [&>pre]:whitespace-pre-wrap [&>pre]:break-words"
+        className="w-full text-sm [&>pre]:p-4 [&>pre]:overflow-x-auto [&>pre]:whitespace-pre-wrap [&>pre]:break-words [&>pre]:bg-background [&>pre]:text-foreground"
       >
         {children?.toString().trim() || ""}
       </ShikiHighlighter>
@@ -52,7 +129,7 @@ export default function CodeSnippet({
       <Button
         variant="ghost"
         onClick={handleCopy}
-        className="absolute z-10 top-2 right-2 text-white hover:bg-zinc-800 rounded-md hover:text-white"
+        className="absolute z-10 top-2 right-2 hover:bg-accent hover:text-accent-foreground rounded-md"
       >
         {copied ? (
           <Check className="size-3" />


### PR DESCRIPTION
… CSS variables
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Implemented a custom Shiki theme for CodeSnippet using our CSS variables, so code highlighting matches the app theme and stays consistent across themes. Also refined styling for better readability and a cleaner copy button.

- **New Features**
  - Custom Shiki theme with token colors mapped to CSS variables (foreground, primary, chart-3/4/5, etc.).

- **Refactors**
  - Replaced laserwave with the custom theme, used bg-background/text-foreground classes, added a border, updated copy button hover to accent, and removed an unused line counter.

<!-- End of auto-generated description by cubic. -->

