### PR TITLE
feat(registry): Changed registry items type. Added missing dependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -12,7 +12,7 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/chapter-intro.tsx",
-          "type": "registry:component",
+          "type": "registry:block",
           "target": "components/ui/8bit/blocks/chapter-intro.tsx"
         },
         {
@@ -979,7 +979,7 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/login-form.tsx",
-          "type": "registry:component",
+          "type": "registry:block",
           "target": "components/ui/8bit/blocks/login-form.tsx"
         },
         {
@@ -1018,7 +1018,7 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/login-form-2.tsx",
-          "type": "registry:component",
+          "type": "registry:block",
           "target": "components/ui/8bit/blocks/login-form-2.tsx"
         },
         {
@@ -1057,7 +1057,7 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/login-form-with-image.tsx",
-          "type": "registry:component",
+          "type": "registry:block",
           "target": "components/ui/8bit/blocks/login-form-with-image.tsx"
         },
         {


### PR DESCRIPTION
I replaced registry type with `registry:block` and registry:page accordingly.
I also replaced `registry:component` with `registry:block` in the registry items:

```
chapter-intro
game-progress
dialogue
login-form
login-form-2
login-form-with-image
chart
chart-bar
chart-area-step
main-menu
pause-menu
game-over
audio-settings
sidebar
difficulty-select
leaderboard
player-profile-card
quest-log
```

I replaced registry:component with registry:page in the registry items: `login-page`, `dashboard-01 `

I noticed that some registry items don’t have dependencies, so when I was installing blocks, there were errors due to missing dependencies.

So I added:
**progress** — `@radix-ui/react-progress`
**game-progress** — `@radix-ui/react-progress`
**dialogue** — `@radix-ui/react-avatar`
**profile-card** — `@radix-ui/react-avatar`
**audio-settings** — `@radix-ui/react-slider, @radix-ui/react-switch`

After these changes, I checked and nothing changed—everything installed just like before :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer UI elements enabled across the app: 8-bit-style progress indicators, chart variations, avatar support, audio sliders/switches, and improved menu/dialogue blocks.
  * Page-level updates for dashboard and login flows for clearer navigation.

* **Chores**
  * Updated internal registry and classifications to better organize components and enable the above UI improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->