### PR TITLE
fix: force target should not be set. components.json should be respected

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -13,18 +13,15 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/chapter-intro.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/chapter-intro.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -37,13 +34,11 @@
       "files": [
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -56,13 +51,11 @@
       "files": [
         {
           "path": "components/ui/8bit/input.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/input.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -75,13 +68,11 @@
       "files": [
         {
           "path": "components/ui/8bit/toast.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/toast.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -94,13 +85,11 @@
       "files": [
         {
           "path": "components/ui/8bit/input-otp.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/input-otp.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -113,13 +102,11 @@
       "files": [
         {
           "path": "components/ui/8bit/badge.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/badge.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -132,13 +119,11 @@
       "files": [
         {
           "path": "components/ui/8bit/textarea.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/textarea.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -151,13 +136,11 @@
       "files": [
         {
           "path": "components/ui/8bit/calendar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/calendar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -171,33 +154,27 @@
       "files": [
         {
           "path": "components/examples/date-picker.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/date-picker.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/calendar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/calendar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/popover.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/popover.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/select.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/select.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -210,13 +187,11 @@
       "files": [
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -229,13 +204,11 @@
       "files": [
         {
           "path": "components/ui/8bit/carousel.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/carousel.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -248,13 +221,11 @@
       "files": [
         {
           "path": "components/ui/8bit/dialog.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/dialog.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -267,13 +238,11 @@
       "files": [
         {
           "path": "components/ui/8bit/dropdown-menu.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/dropdown-menu.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -286,13 +255,11 @@
       "files": [
         {
           "path": "components/ui/8bit/hover-card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/hover-card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -305,13 +272,11 @@
       "files": [
         {
           "path": "components/ui/8bit/popover.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/popover.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -324,13 +289,11 @@
       "files": [
         {
           "path": "components/ui/8bit/resizable.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/resizable.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -343,13 +306,11 @@
       "files": [
         {
           "path": "components/ui/8bit/select.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/select.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -362,13 +323,11 @@
       "files": [
         {
           "path": "components/ui/8bit/sheet.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/sheet.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -381,13 +340,11 @@
       "files": [
         {
           "path": "components/ui/8bit/label.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/label.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -400,13 +357,11 @@
       "files": [
         {
           "path": "components/ui/8bit/checkbox.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/checkbox.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -420,13 +375,11 @@
       "files": [
         {
           "path": "components/ui/8bit/scroll-area.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/scroll-area.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -439,13 +392,11 @@
       "files": [
         {
           "path": "components/ui/8bit/switch.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/switch.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -458,13 +409,11 @@
       "files": [
         {
           "path": "components/ui/8bit/alert.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/alert.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -477,13 +426,11 @@
       "files": [
         {
           "path": "components/ui/8bit/alert-dialog.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/alert-dialog.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -496,13 +443,11 @@
       "files": [
         {
           "path": "components/ui/8bit/tooltip.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/tooltip.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -515,13 +460,11 @@
       "files": [
         {
           "path": "components/ui/8bit/tooltip.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/tooltip.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -534,13 +477,11 @@
       "files": [
         {
           "path": "components/ui/8bit/avatar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/avatar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -553,13 +494,11 @@
       "files": [
         {
           "path": "components/ui/8bit/skeleton.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/skeleton.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -572,13 +511,11 @@
       "files": [
         {
           "path": "components/ui/8bit/breadcrumb.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/breadcrumb.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -591,13 +528,11 @@
       "files": [
         {
           "path": "components/ui/8bit/collapsible.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/collapsible.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -611,13 +546,11 @@
       "files": [
         {
           "path": "components/ui/8bit/progress.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/progress.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -630,23 +563,19 @@
       "files": [
         {
           "path": "components/ui/8bit/enemy-health-display.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/enemy-health-display.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/health-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/health-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/progress.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/progress.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -659,18 +588,15 @@
       "files": [
         {
           "path": "components/ui/8bit/health-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/health-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/progress.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/progress.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -683,18 +609,15 @@
       "files": [
         {
           "path": "components/ui/8bit/mana-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/mana-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/progress.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/progress.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -709,28 +632,23 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/game-progress.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/game-progress.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/health-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/health-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/mana-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/mana-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/progress.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/progress.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -745,23 +663,19 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/dialogue.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/dialogue.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/alert.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/alert.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/avatar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/avatar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -775,28 +689,23 @@
       "files": [
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/avatar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/avatar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/badge.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/badge.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -809,13 +718,11 @@
       "files": [
         {
           "path": "components/ui/8bit/slider.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/slider.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -828,13 +735,11 @@
       "files": [
         {
           "path": "components/ui/8bit/context-menu.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/context-menu.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -847,13 +752,11 @@
       "files": [
         {
           "path": "components/ui/8bit/menubar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/menubar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -866,13 +769,11 @@
       "files": [
         {
           "path": "components/ui/8bit/toggle.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/toggle.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -885,13 +786,11 @@
       "files": [
         {
           "path": "components/ui/8bit/table.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/table.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -904,13 +803,11 @@
       "files": [
         {
           "path": "components/ui/8bit/tabs.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/tabs.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -923,18 +820,15 @@
       "files": [
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/popover.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/popover.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -947,18 +841,15 @@
       "files": [
         {
           "path": "components/ui/8bit/command.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/command.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/separator.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/separator.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -971,8 +862,7 @@
       "files": [
         {
           "path": "components/ui/8bit/separator.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/separator.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -985,13 +875,11 @@
       "files": [
         {
           "path": "components/ui/8bit/radio-group.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/radio-group.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1004,13 +892,11 @@
       "files": [
         {
           "path": "components/ui/8bit/pagination.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/pagination.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1023,28 +909,23 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/friend-list.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/friend-list.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/scroll-area.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/scroll-area.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/avatar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/avatar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1058,33 +939,27 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/login-form.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/login-form.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/input.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/input.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/label.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/label.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1098,33 +973,27 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/login-form-2.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/login-form-2.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/input.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/input.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/label.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/label.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1138,33 +1007,27 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/login-form-with-image.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/login-form-with-image.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/input.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/input.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/label.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/label.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1178,38 +1041,31 @@
       "files": [
         {
           "path": "app/login/page.tsx",
-          "type": "registry:component",
-          "target": "app/login/page.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/blocks/login-form.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/login-form.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/input.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/input.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/label.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/label.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1223,18 +1079,15 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/chart.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/chart.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/chart.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/chart.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1248,18 +1101,15 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/chart-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/blocks/chart-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/chart.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/chart.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1273,18 +1123,15 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/chart-area-step.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/blocks/chart-area-step.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/chart.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/chart.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1298,23 +1145,19 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/main-menu.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/blocks/main-menu.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -1328,23 +1171,19 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/pause-menu.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/pause-menu.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -1358,23 +1197,19 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/game-over.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/game-over.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -1389,33 +1224,27 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/audio-settings.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/audio-settings.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/switch.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/switch.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/slider.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/slider.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/label.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/label.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -1428,13 +1257,11 @@
       "files": [
         {
           "path": "components/ui/8bit/toggle-group.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/toggle-group.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1448,13 +1275,11 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/sidebar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/blocks/sidebar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1467,13 +1292,11 @@
       "files": [
         {
           "path": "components/ui/8bit/accordion.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/accordion.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1486,13 +1309,11 @@
       "files": [
         {
           "path": "components/ui/8bit/drawer.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/drawer.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1505,13 +1326,11 @@
       "files": [
         {
           "path": "components/ui/8bit/navigation-menu.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/navigation-menu.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1525,23 +1344,19 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/difficulty-select.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/blocks/difficulty-select.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -1555,33 +1370,27 @@
       "files": [
         {
           "path": "components/ui/8bit/leaderboard.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/leaderboard.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/avatar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/avatar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/badge.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/badge.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/separator.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/separator.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -1595,43 +1404,35 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/player-profile-card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/blocks/player-profile-card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/avatar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/avatar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/badge.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/badge.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/health-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/health-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/mana-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/mana-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/progress.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/progress.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1645,33 +1446,27 @@
       "files": [
         {
           "path": "components/ui/8bit/quest-log.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/quest-log.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/accordion.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/accordion.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/badge.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/badge.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/scroll-area.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/scroll-area.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1684,33 +1479,27 @@
       "files": [
         {
           "path": "components/ui/8bit/save-slots.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/save-slots.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/badge.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/badge.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/separator.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/separator.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -1750,113 +1539,91 @@
       "files": [
         {
           "path": "app/dashboard/page.tsx",
-          "type": "registry:component",
-          "target": "app/dashboard/page.tsx"
+          "type": "registry:component"
         },
         {
           "path": "app/dashboard/data.json",
-          "type": "registry:component",
-          "target": "app/dashboard/data.json"
+          "type": "registry:component"
         },
         {
           "path": "components/dashboard-header.tsx",
-          "type": "registry:component",
-          "target": "components/dashboard-header.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/section-cards.tsx",
-          "type": "registry:component",
-          "target": "components/section-cards.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/data-table.tsx",
-          "type": "registry:component",
-          "target": "components/data-table.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/blocks/chart-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/blocks/chart-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/badge.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/badge.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/skeleton.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/skeleton.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/chart.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/chart.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/checkbox.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/checkbox.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/drawer.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/drawer.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/dropdown-menu.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/dropdown-menu.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/input.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/input.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/label.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/label.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/select.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/select.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/separator.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/separator.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/table.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/table.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/tabs.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/tabs.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/sidebar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/sidebar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1869,33 +1636,27 @@
       "files": [
         {
           "path": "components/select-theme-dropdown.tsx",
-          "type": "registry:component",
-          "target": "components/select-theme-dropdown.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/active-theme.tsx",
-          "type": "registry:component",
-          "target": "components/active-theme.tsx"
+          "type": "registry:component"
         },
         {
           "path": "lib/themes.ts",
-          "type": "registry:component",
-          "target": "lib/themes.ts"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/select.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/select.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         },
         {
           "path": "app/retro-globals.css",
-          "type": "registry:component",
-          "target": "app/retro-globals.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1908,8 +1669,7 @@
       "files": [
         {
           "path": "components/ui/8bit/spinner.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/spinner.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -1922,13 +1682,11 @@
       "files": [
         {
           "path": "components/ui/8bit/kbd.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/kbd.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1942,23 +1700,19 @@
       "files": [
         {
           "path": "components/ui/retro-mode-switcher.tsx",
-          "type": "registry:component",
-          "target": "components/ui/retro-mode-switcher.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/button.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/button.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/theme-provider.tsx",
-          "type": "registry:component",
-          "target": "components/theme-provider.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -1971,8 +1725,7 @@
       "files": [
         {
           "path": "components/ui/8bit/empty.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/empty.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -1985,8 +1738,7 @@
       "files": [
         {
           "path": "components/ui/8bit/item.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/item.tsx"
+          "type": "registry:component"
         }
       ]
     },
@@ -2006,48 +1758,39 @@
       "files": [
         {
           "path": "components/ui/8bit/character-sheet.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/character-sheet.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/avatar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/avatar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/badge.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/badge.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/health-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/health-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/mana-bar.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/mana-bar.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/progress.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/progress.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/separator.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/separator.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     },
@@ -2061,28 +1804,23 @@
       "files": [
         {
           "path": "components/ui/8bit/blocks/victory-screen.tsx",
-          "type": "registry:block",
-          "target": "components/ui/8bit/blocks/victory-screen.tsx"
+          "type": "registry:block"
         },
         {
           "path": "components/ui/8bit/item.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/item.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/card.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/card.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/alert.tsx",
-          "type": "registry:component",
-          "target": "components/ui/8bit/alert.tsx"
+          "type": "registry:component"
         },
         {
           "path": "components/ui/8bit/styles/retro.css",
-          "type": "registry:component",
-          "target": "components/ui/8bit/styles/retro.css"
+          "type": "registry:component"
         }
       ]
     }


### PR DESCRIPTION
There was an issue with the component directory in the project is not being respected. Current config is the following;

components.json:
```
{
  "$schema": "https://ui.shadcn.com/schema.json",
  "style": "new-york",
  "rsc": false,
  "tsx": true,
  "tailwind": {
    "config": "",
    "css": "app/app.css",
    "baseColor": "zinc",
    "cssVariables": true,
    "prefix": ""
  },
  "iconLibrary": "lucide",
  "aliases": {
    "components": "~/components",
    "utils": "~/lib/utils",
    "ui": "~/components/ui",
    "lib": "~/lib",
    "hooks": "~/hooks"
  },
  "registries": {
    "@8bitcn": "http://localhost:3001/r/{name}.json"
  }
}
```

tsconfig.json:
```
{
  "include": [
    "**/*",
    "**/.server/**/*",
    "**/.client/**/*",
    ".react-router/types/**/*"
  ],
  "compilerOptions": {
    "lib": ["DOM", "DOM.Iterable", "ES2022"],
    "types": ["node", "vite/client"],
    "target": "ES2022",
    "module": "ES2022",
    "moduleResolution": "bundler",
    "jsx": "react-jsx",
    "rootDirs": [".", "./.react-router/types"],
    "baseUrl": ".",
    "paths": {
      "~/*": ["./app/*"],
    },
    "esModuleInterop": true,
    "verbatimModuleSyntax": true,
    "noEmit": true,
    "resolveJsonModule": true,
    "skipLibCheck": true,
    "strict": true
  }
}
```

With this config, I expect the components to be placed in the ./app/components dir, as in the official shadcn-ui components.
But the expected behavior did not match with the current one. No config prevented the command `npx shadcn@latest add @8bitcn/button` to save the files to ./components directory instead of ./app/components.

This PR solves this issue by respecting the shadcn cli config instead of forcing the target directory manually.

Previous behavior;
```
> npx shadcn@latest add @8bitcn/health-bar
✔ Checking registry.
✔ Installing dependencies.
✔ The file health-bar.tsx already exists. Would you like to overwrite? … yes
ℹ Updated 1 file:
  - components/ui/8bit/health-bar.tsx // -> saved to ./components/ folder
ℹ Skipped 3 file: (files might be identical, use --overwrite to overwrite)
  - app/components/ui/progress.tsx
  - components/ui/8bit/progress.tsx // -> saved to ./components/ folder
  - components/ui/8bit/styles/retro.css // -> saved to ./components/ folder
  ```
  
  Current behavior;
  ```
  > npx shadcn@latest add @8bitcn/health-bar 
✔ Checking registry.
✔ Installing dependencies.
✔ Created 3 files:
  - app/components/ui/8bit/health-bar.tsx // -> respected to config, saved to ./app/components/ folder
  - app/components/ui/8bit/progress.tsx // -> respected to config, saved to ./app/components/ folder
  - app/components/ui/8bit/styles/retro.css // -> respected to config, saved to ./app/components/ folder
ℹ Skipped 1 files: (files might be identical, use --overwrite to overwrite)
  - app/components/ui/progress.tsx
  ```
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined configuration data structure by removing the target field from all file entries. File entries now contain only path and type information, reducing data complexity while maintaining complete functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->