### PR TITLE
fix(docs): global header styles broken on mobile

### DIFF
--- a/components/search-documentation.tsx
+++ b/components/search-documentation.tsx
@@ -12,7 +12,7 @@ export function SearchDocumentation() {
   return (
     <Button
       className={cn(
-        "retro relative h-8 w-full justify-start bg-muted/50 font-normal text-[7.5px] text-muted-foreground shadow-none sm:pr-12 md:w-40 lg:w-56 xl:w-64"
+        "retro relative h-8 w-full max-w-[75%] justify-start bg-muted/50 font-normal text-[7.5px] text-muted-foreground shadow-none sm:pr-12 md:w-40 lg:w-56 xl:w-64"
       )}
       onClick={() => setOpenSearch(true)}
       variant="outline"

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -13,7 +13,7 @@ import { Skeleton } from "./ui/8bit/skeleton";
 export function SiteHeader() {
   return (
     <header className="sticky top-0 z-50 flex h-14 shrink-0 items-center gap-2 border-b border-dashed bg-background/95">
-      <div className="mx-auto flex h-full w-full max-w-[1400px] items-center gap-1 border-r border-l border-dashed px-4 md:gap-5 md:px-6">
+      <div className="flex h-full w-full max-w-[1400px] items-center gap-2 border-r border-l border-dashed px-2 md:mx-auto md:gap-5 md:px-6">
         <Link className="hidden items-center gap-2 md:flex" href="/">
           <Image alt="logo" height={32} src="/8bitcn.png" width={32} />{" "}
           <h2 className={`${"retro"} hidden font-bold text-xs md:inline-block`}>
@@ -36,7 +36,7 @@ export function SiteHeader() {
             </Link>
           ))}
         </nav>
-        <div className="ml-auto flex items-center gap-2">
+        <div className="flex items-center gap-2 md:ml-auto">
           <SearchDocumentation />
 
           <Link href="https://github.com/TheOrcDev/8bitcn-ui" target="_blank">


### PR DESCRIPTION
## Description
Global navbar header is broken on mobile and shifts the whole layout on the left and messing up the scaling.

### Current Header:
![broken_header](https://github.com/user-attachments/assets/941935ed-d986-4e2a-a4b8-773c4d43a81a)

### With Fix Header:
![fixed_header](https://github.com/user-attachments/assets/fa12fd5b-1f5f-48be-9ff0-2d2688cfa550)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the search button's maximum width on larger screens for better visual proportions.
  * Modified site header layout spacing and responsive alignment for improved consistency across different screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->