### PR TITLE
docs(components): Sidebar preview

### DIFF
--- a/components/examples/sidebar.tsx
+++ b/components/examples/sidebar.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+    SidebarProvider,
+    Sidebar,
+    SidebarContent,
+    SidebarGroupLabel,
+    SidebarGroup,
+    SidebarMenu,
+    SidebarMenuItem,
+    SidebarMenuButton,
+    SidebarMenuSub,
+    SidebarMenuSubItem,
+    SidebarMenuSubButton,
+    SidebarInset,
+    SidebarTrigger,
+} from "@/components/ui/sidebar";
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ChevronDown } from "lucide-react";
+
+type SidebarExampleMenu = {
+    imgSrc: string;
+    imgAlt: string;
+    title: string;
+    subMenus: string[];
+};
+
+export function SidebarExample() {
+    const menus: SidebarExampleMenu[] = [
+        {
+            imgSrc: "/icons/sword.png",
+            imgAlt: "Sword",
+            title: "Weapons",
+            subMenus: ["Ironfang", "Stormcleaver", "Duskblade"],
+        },
+        {
+            imgSrc: "/icons/shield.png",
+            imgAlt: "Shield",
+            title: "Shields",
+            subMenus: ["Mirrorwall", "Hearthguard", "Oathkeeper"],
+        },
+        {
+            imgSrc: "/images/goblin.png",
+            imgAlt: "Goblin",
+            title: "Monsters",
+            subMenus: ["Goblin", "Giant", "Dragon"],
+        },
+    ];
+
+    return (
+        <div style={{
+            border: "1px var(--border) solid",
+            width: "100%",
+        }}>
+            <SidebarProvider style={{
+                minHeight: 350,
+                maxHeight: 350,
+            }}>
+                <Sidebar collapsible="icon" style={{
+                    position: "relative",
+                    maxHeight: 350,
+                    overflowY: "auto",
+                }}>
+                    <SidebarContent>
+                        <SidebarGroup>
+                            <SidebarGroupLabel>Lore</SidebarGroupLabel>
+                            <SidebarMenu>
+                                {menus.map(menu => <CollapsibleSidebarMenu key={menu.title} menu={menu} />)}
+                            </SidebarMenu>
+                        </SidebarGroup>
+                    </SidebarContent>
+                </Sidebar>
+                <SidebarInset>
+                    <SidebarTrigger />
+                </SidebarInset>
+            </SidebarProvider>
+        </div>
+    )
+}
+
+function CollapsibleSidebarMenu({ menu }: { menu: SidebarExampleMenu }) {
+    return (
+        <Collapsible asChild>
+            <SidebarMenuItem>
+                <CollapsibleTrigger asChild>
+                    <SidebarMenuButton>
+                        <img src={menu.imgSrc} style={{ width: "16px" }} alt={menu.imgAlt} />
+                        <span>{menu.title}</span>
+                        <ChevronDown className="ml-auto" />
+                    </SidebarMenuButton>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                    <SidebarMenuSub>
+                        {menu.subMenus.map(subMenu => <CollapsibleSidebarSubMenu key={subMenu} subMenu={subMenu} />)}
+                    </SidebarMenuSub>
+                </CollapsibleContent>
+            </SidebarMenuItem>
+        </Collapsible>
+    );
+}
+
+function CollapsibleSidebarSubMenu({ subMenu }: { subMenu: string }) {
+    return (
+        <SidebarMenuSubItem>
+            <SidebarMenuSubButton>
+                {subMenu}
+            </SidebarMenuSubButton>
+        </SidebarMenuSubItem>
+    );
+}

--- a/content/docs/components/sidebar.mdx
+++ b/content/docs/components/sidebar.mdx
@@ -6,79 +6,7 @@ description: Displays a simple 8-bit sidebar component.
 import CopyCommandButton from "@/components/copy-command-button";
 import InstallationCommands from "@/components/installation-commands";
 import ComponentPreview from "@/components/component-preview";
-import {
-  SidebarProvider,
-  Sidebar,
-  SidebarContent,
-  SidebarGroupLabel,
-  SidebarGroup,
-  SidebarMenu,
-  SidebarMenuItem,
-  SidebarMenuButton,
-  SidebarMenuSub,
-  SidebarMenuSubItem,
-  SidebarMenuSubButton,
-  SidebarInset,
-  SidebarTrigger,
-} from "@/components/ui/sidebar";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { ChevronDown } from "lucide-react";
-
-export const menus = [
-  {
-    imgSrc: "/icons/sword.png",
-    imgAlt: "Sword",
-    title: "Weapons",
-    subMenus: ["Ironfang", "Stormcleaver", "Duskblade"],
-  },
-  {
-    imgSrc: "/icons/shield.png",
-    imgAlt: "Shield",
-    title: "Shields",
-    subMenus: ["Mirrorwall", "Hearthguard", "Oathkeeper"],
-  },
-  {
-    imgSrc: "/images/goblin.png",
-    imgAlt: "Goblin",
-    title: "Monsters",
-    subMenus: ["Goblin", "Giant", "Dragon"],
-  },
-];
-
-export function CollapsibleSidebarMenu({menu}) {
-  return (
-    <Collapsible asChild>
-      <SidebarMenuItem>
-        <CollapsibleTrigger asChild>
-          <SidebarMenuButton>
-            <img src={menu.imgSrc} style={{width: "16px"}} alt={menu.imgAlt} />
-            <span>{menu.title}</span>
-            <ChevronDown className="ml-auto" />
-          </SidebarMenuButton>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <SidebarMenuSub>
-            { menu.subMenus.map(subMenu => <CollapsibleSidebarSubMenu key={subMenu} subMenu={subMenu} />) }
-          </SidebarMenuSub>
-        </CollapsibleContent>
-      </SidebarMenuItem>
-    </Collapsible>
-  );
-}
-
-export function CollapsibleSidebarSubMenu({subMenu}) {
-  return (
-    <SidebarMenuSubItem>
-      <SidebarMenuSubButton>
-        {subMenu}
-      </SidebarMenuSubButton>
-    </SidebarMenuSubItem>
-  );
-}
+import { SidebarExample } from "@/components/examples/sidebar"
 
 <div className="flex flex-col md:flex-row items-center justify-end gap-2 mb-2">
   <CopyCommandButton
@@ -88,26 +16,7 @@ export function CollapsibleSidebarSubMenu({subMenu}) {
 </div>
 
 <ComponentPreview title="8-bit Sidebar component" name="sidebar">
-  <div style={{
-    border: "1px var(--border) solid",
-    width: "100%",
-  }}>
-    <SidebarProvider style={{minHeight: 350, maxHeight: 350}}>
-      <Sidebar collapsible="icon" style={{position: "relative", maxHeight: 350, overflowY: "auto"}}>
-        <SidebarContent>
-          <SidebarGroup>
-            <SidebarGroupLabel>Lore</SidebarGroupLabel>
-            <SidebarMenu>
-              { menus.map(menu => <CollapsibleSidebarMenu key={menu.title} menu={menu} />) }
-            </SidebarMenu>
-          </SidebarGroup>
-        </SidebarContent>
-      </Sidebar>
-      <SidebarInset>
-        <SidebarTrigger />
-      </SidebarInset>
-    </SidebarProvider>
-  </div>
+  <SidebarExample />
 </ComponentPreview>
 
 ## Installation


### PR DESCRIPTION
## Summary
Add preview for Sidebar component in the docs.
Closes #512 

## Screenshoot
<img width="718" height="699" alt="image" src="https://github.com/user-attachments/assets/6670bba4-45a1-41a9-a0b2-5e22cc3d7db7" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive 8‑bit collapsible sidebar with expandable menu groups, icons, and sub-items for richer navigation.
  * Introduced a data‑driven menu structure enabling grouped sections and visual previews.

* **Documentation**
  * Embedded a live component preview in the docs demonstrating the collapsible sidebar and its hierarchical behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->