### PR TITLE
feat: replace ModeSwitcher with RetroModeSwitcher in SiteHeader and u…

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
 import { Suspense } from "react";
-import { ModeSwitcher } from "@/components/mode-switcher";
 
 import { Button } from "@/components/ui/button";
 import { navItems } from "@/config/nav-items";
@@ -9,6 +8,7 @@ import { navItems } from "@/config/nav-items";
 import MobileNav from "./mobile-nav";
 import { SearchDocumentation } from "./search-documentation";
 import { Skeleton } from "./ui/8bit/skeleton";
+import { RetroModeSwitcher } from "./ui/retro-mode-switcher";
 
 export function SiteHeader() {
   return (
@@ -54,7 +54,7 @@ export function SiteHeader() {
               </Suspense>
             </Button>
           </Link>
-          <ModeSwitcher />
+          <RetroModeSwitcher className="size-7" />
         </div>
       </div>
     </header>

--- a/components/ui/retro-mode-switcher.tsx
+++ b/components/ui/retro-mode-switcher.tsx
@@ -5,8 +5,13 @@ import * as React from "react";
 import { useTheme } from "next-themes";
 
 import { Button } from "@/components/ui/8bit/button";
+import { cn } from "@/lib/utils";
 
-export function RetroModeSwitcher() {
+interface RetroModeSwitcherProps {
+  className?: string;
+}
+
+export function RetroModeSwitcher({ className }: RetroModeSwitcherProps) {
   const { setTheme, resolvedTheme } = useTheme();
 
   const toggleTheme = React.useCallback(() => {
@@ -27,7 +32,7 @@ export function RetroModeSwitcher() {
         xmlns="http://www.w3.org/2000/svg"
         stroke="currentColor"
         strokeWidth="0.25"
-        className="size-8 hidden [html.dark_&]:block"
+        className={cn("size-8 hidden [html.dark_&]:block", className)}
         aria-label="sun-dim"
       >
         <rect x="120" y="88" width="14" height="14" rx="1"></rect>
@@ -67,7 +72,7 @@ export function RetroModeSwitcher() {
         xmlns="http://www.w3.org/2000/svg"
         stroke="currentColor"
         strokeWidth="0.25"
-        className="hidden [html.light_&]:block size-8"
+        className={cn("hidden [html.light_&]:block size-8", className)}
         aria-label="moon"
       >
         <rect x="104" y="56" width="14" height="14" rx="1"></rect>


### PR DESCRIPTION
…pdate RetroModeSwitcher to accept className prop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Replaced the standard theme switcher with a retro-inspired version featuring updated visual styling and optimized sizing.

* **Refactor**
  * Enhanced the theme switcher component architecture to support flexible customization through external styling options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->