### PR TITLE
fix: added radix separator as deps

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -972,6 +972,7 @@
       "type": "registry:component",
       "title": "8-bit Separator",
       "description": "A simple 8-bit separator component",
+      "dependencies": ["@radix-ui/react-separator"],
       "registryDependencies": [],
       "files": [
         {


### PR DESCRIPTION
The separator component uses the `@radix-ui/react-separator` dependency, which might not be present in the project by default. If you try to install the component in a clean project, you’ll get the error:

```
Failed to resolve import `@radix-ui/react-separator` from `src/components/ui/8bit/separator.tsx`. Does the file exist?
```

If you create a project using shadcn create, this error doesn’t occur. However, in existing projects, this error will appear. That’s why I added `@radix-ui/react-separator` as a dependency for separator in `registry.json`