### PR TITLE
fix: lint errors — rel=noopener + negation inversion

### DIFF
--- a/components/profile-card.tsx
+++ b/components/profile-card.tsx
@@ -73,7 +73,7 @@ export default function ProfileCard({
           <div className="flex items-center gap-3 text-sm">
             {safeGithubUrl && (
               <Button asChild size="icon">
-                <a href={safeGithubUrl} target="_blank">
+                <a href={safeGithubUrl} rel="noopener" target="_blank">
                   <svg
                     className="size-7"
                     fill="currentColor"
@@ -155,7 +155,7 @@ export default function ProfileCard({
 
             {safeXUrl && (
               <Button asChild size="icon">
-                <a href={safeXUrl} target="_blank">
+                <a href={safeXUrl} rel="noopener" target="_blank">
                   <svg
                     className="size-6"
                     fill="currentColor"

--- a/components/search.tsx
+++ b/components/search.tsx
@@ -85,7 +85,7 @@ export default function DefaultSearchDialog(props: SharedProps) {
             <Kbd>ESC</Kbd>
           </SearchDialogClose>
         </SearchDialogHeader>
-        <SearchDialogList items={query.data !== "empty" ? query.data : null} />
+        <SearchDialogList items={query.data === "empty" ? null : query.data} />
 
         {search ? null : (
           <div className="flex flex-col">


### PR DESCRIPTION
## Changes

- **profile-card.tsx**: Add `rel="noopener"` to `target="_blank"` links (security — prevents reverse tabnapping)
- **search.tsx**: Invert negation condition (`!== "empty" ? x : null` → `=== "empty" ? null : x`) per Biome lint rule

## Verification

`pnpm check` passes clean (0 errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added security attributes to external links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->