### PR TITLE
fix: registry install for blocks using custom bar components

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -710,7 +710,7 @@
       "description": "A simple 8-bit game progress component",
       "dependencies": ["@radix-ui/react-progress"],
       "categories": ["gaming"],
-      "registryDependencies": ["card", "health-bar", "mana-bar", "progress"],
+      "registryDependencies": ["card", "progress"],
       "files": [
         {
           "path": "components/ui/8bit/blocks/game-progress.tsx",
@@ -1604,14 +1604,7 @@
       "type": "registry:block",
       "title": "8-bit Player Profile Card",
       "description": "A comprehensive player profile card component with stats, health/mana bars, and custom stats support.",
-      "registryDependencies": [
-        "avatar",
-        "badge",
-        "card",
-        "health-bar",
-        "mana-bar",
-        "progress"
-      ],
+      "registryDependencies": ["avatar", "badge", "card", "progress"],
       "categories": ["gaming"],
       "files": [
         {
@@ -2022,8 +2015,6 @@
         "avatar",
         "badge",
         "card",
-        "health-bar",
-        "mana-bar",
         "progress",
         "separator"
       ],


### PR DESCRIPTION
## Summary
Fix registry install failures for blocks that use custom 8bit components like `health-bar` / `mana-bar`.

- Remove custom bar components from `registryDependencies` (they were being resolved against shadcn default registry and failing).
- Keep those custom components in each block `files` list so installs still include required code.

## Why
`shadcn add` for blocks like `@8bitcn/game-progress` and `@8bitcn/character-sheet` failed with:
- `The item at https://ui.shadcn.com/r/styles/default/health-bar.json was not found`

## Verification
- `pnpm check`
- dry-run install test from another project


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated component dependencies across game progress, player profile card, and character sheet components by removing health bar and mana bar references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->