### PR TITLE
fix: remove mobile horizontal scroll in showcase

### DIFF
--- a/components/examples/component-showcase.tsx
+++ b/components/examples/component-showcase.tsx
@@ -385,8 +385,8 @@ export default function ComponentShowcase() {
                   <SelectItem value="system">System</SelectItem>
                 </SelectContent>
               </Select>
-              <div className="flex items-center justify-center">
-                <DatePicker className="w-[300px]" />
+              <div className="flex w-full items-center justify-center">
+                <DatePicker className="w-full max-w-[300px]" />
               </div>
               <EnemyHealthDisplay
                 currentHealth={850}

--- a/components/examples/date-picker.tsx
+++ b/components/examples/date-picker.tsx
@@ -20,7 +20,7 @@ export function DatePicker({ className }: HTMLAttributes<HTMLDivElement>) {
       <PopoverTrigger asChild>
         <Button
           className={cn(
-            "w-[310px] justify-start text-left font-normal",
+            "w-full max-w-[310px] justify-start text-left font-normal",
             !date && "text-muted-foreground",
             className
           )}


### PR DESCRIPTION
## Summary
Fix mobile horizontal overflow caused by fixed-width date picker sizing in showcase.

### Changes
- `components/examples/date-picker.tsx`
  - `w-[310px]` -> `w-full max-w-[310px]`
- `components/examples/component-showcase.tsx`
  - make date-picker container `w-full`
  - pass `w-full max-w-[300px]` to DatePicker

## Verification
- `pnpm check`
- mobile viewport no longer overflows horizontally in showcase


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated DatePicker component styling to use responsive width constraints. The component now expands to fill its container up to a maximum width instead of using fixed dimensions, improving layout behavior across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->