### PR TITLE
fix(component-showcase) remove w-full from date picker

### DIFF
--- a/components/examples/component-showcase.tsx
+++ b/components/examples/component-showcase.tsx
@@ -385,7 +385,7 @@ export default function ComponentShowcase() {
                   <SelectItem value="system">System</SelectItem>
                 </SelectContent>
               </Select>
-              <div className="flex w-full items-center justify-center">
+              <div className="flex items-center justify-center">
                 <DatePicker className="w-full max-w-[300px]" />
               </div>
               <EnemyHealthDisplay


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted DatePicker component layout to size based on content rather than expanding to full width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->