### PR TITLE
feat: add theme toggle hotkey

### DIFF
--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,11 +1,64 @@
 "use client";
 
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
 import type * as React from "react";
+import { useEffect } from "react";
 
 export function ThemeProvider({
   children,
   ...props
 }: React.ComponentProps<typeof NextThemesProvider>) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  return (
+    <NextThemesProvider {...props}>
+      <ThemeHotkey />
+      {children}
+    </NextThemesProvider>
+  );
+}
+
+function isTypingTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return (
+    target.isContentEditable ||
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "SELECT"
+  );
+}
+
+function ThemeHotkey() {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.defaultPrevented || event.repeat) {
+        return;
+      }
+
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+
+      if (event.key.toLowerCase() !== "d") {
+        return;
+      }
+
+      if (isTypingTarget(event.target)) {
+        return;
+      }
+
+      setTheme(resolvedTheme === "dark" ? "light" : "dark");
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [resolvedTheme, setTheme]);
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- add a global  hotkey to toggle light and dark themes
- ignore the shortcut while typing in inputs, textareas, selects, and contenteditable fields
- mirror the same theme hotkey behavior used in other projects

## Testing
- pnpm check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut to toggle between light and dark themes by pressing the "d" key when not actively typing in input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->