### PR TITLE
chore: remove shadcn space as a sponsor

### DIFF
--- a/components/sponsors.tsx
+++ b/components/sponsors.tsx
@@ -52,12 +52,6 @@ const legendarySponsors = [
     image: "/sponsors/inbound.svg",
     invert: false,
   },
-  {
-    name: "shadcnspace",
-    url: "https://shadcnspace.com/",
-    image: "/sponsors/shadcnspace.png",
-    invert: false,
-  },
 ];
 
 // const sponsors = [


### PR DESCRIPTION
## Summary

- Removes shadcnspace from the legendary sponsors list in `components/sponsors.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed one sponsor from the legendary sponsors section. This sponsor will no longer be displayed in the dedicated sponsors area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->