### PR TITLE
fix(Hero2): render visual prop instead of hardcoded image

### DIFF
--- a/components/ui/8bit/blocks/hero2.tsx
+++ b/components/ui/8bit/blocks/hero2.tsx
@@ -106,7 +106,15 @@ export default function Hero2({
         </div>
 
         {/* Visual side */}
-        <img src="/images/8bit-orc.png" alt="Hero 2" className="w-full h-full object-cover" />
+        {visual ? (
+          <div className="w-full h-full">{visual}</div>
+        ) : (
+          <img
+            src="/images/8bit-orc.png"
+            alt="Hero 2"
+            className="w-full h-full object-cover"
+          />
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
This patch correctly displays the visual prop, falling back to the default 8bit-orc image if no visual is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The hero section can now display a custom visual on the right side when provided.
  * If no custom visual is set, it continues to show the existing default image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->