### PR TITLE
docs(readme): redesign header with shieldcn badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,29 @@
-## 8bitcn/ui
+<div align="center">
 
-Accessible retro components that you can copy and paste into your apps. Free. Open Source.
+<a href="https://8bitcn.com">
+  <img alt="8bitcn/ui — Accessible retro components you can copy and paste" width="750" src="https://shieldcn.dev/header/glow.svg?title=8bitcn%2Fui&subtitle=Accessible%20retro%20components%20you%20can%20copy%20and%20paste&logo=shadcnui&pattern=grid&glow=22c55e&mode=dark&titleColor=22c55e">
+</a>
 
-Visit [8bitcn.com](https://8bitcn.com/)
+<p><strong>Free. Open Source. Built on shadcn/ui.</strong></p>
 
-[![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=❤&logo=GitHub&color=#fe8e86)](https://github.com/sponsors/theorcdev)
+<p>
+  <a href="https://github.com/TheOrcDev/8bitcn-ui/stargazers"><img alt="Stars" src="https://shieldcn.dev/github/stars/TheOrcDev/8bitcn-ui.svg"></a>
+  <a href="https://github.com/TheOrcDev/8bitcn-ui/forks"><img alt="Forks" src="https://shieldcn.dev/github/forks/TheOrcDev/8bitcn-ui.svg"></a>
+  <a href="https://discord.com/invite/uFB5YzH9YG"><img alt="Discord" src="https://shieldcn.dev/discord/members/uFB5YzH9YG.svg"></a>
+  <a href="/license.md"><img alt="License" src="https://shieldcn.dev/github/license/TheOrcDev/8bitcn-ui.svg"></a>
+  <a href="https://ui.shadcn.com"><img alt="Built with shadcn/ui" src="https://shieldcn.dev/badge/built_with-shadcn%2Fui.svg?logo=shadcnui"></a>
+  <a href="https://github.com/sponsors/theorcdev"><img alt="Sponsor" src="https://shieldcn.dev/badge/sponsor-%E2%9D%A4-pink.svg?logo=githubsponsors"></a>
+</p>
+
+<p>
+  <a href="https://8bitcn.com/docs"><strong>Documentation</strong></a> ·
+  <a href="https://8bitcn.com/docs/components"><strong>Components</strong></a> ·
+  <a href="https://8bitcn.com/docs/blocks"><strong>Blocks</strong></a> ·
+  <a href="https://8bitcn.com/themes"><strong>Themes</strong></a> ·
+  <a href="https://discord.com/invite/uFB5YzH9YG"><strong>Discord</strong></a>
+</p>
+
+</div>
 
 ![8bitcn UI Components](./public/assets/8bitcn-readme-showcase.png)
 


### PR DESCRIPTION
Rebuilds the top of the README using [shieldcn.dev](https://shieldcn.dev/studio). Everything from `## Contributing` down is untouched.

## What changed

- **Header banner** — `header/glow.svg` with a grid pattern and terminal-green glow, matching the retro aesthetic (and the `theme=terminal` star-history badge already at the bottom of the file). Links to 8bitcn.com.
- **Badge row** — stars, forks, Discord, license, built-with-shadcn/ui, sponsor.
- **Quick links** — Documentation · Components · Blocks · Themes · Discord.

## Verification

- Every badge returns live data (stars 2.0k, forks 117, MIT, Discord 1.1k members), checked via each endpoint's `.json` form.
- Every link resolves — `/components` and `/docs/installation` are 404s, so the real paths (`/docs/components`, `/docs/blocks`) are used.
- Rendered through GitHub's own markdown API and viewed on both `#ffffff` and `#0d1117`. The badges have baked-in colors and no `prefers-color-scheme` query, so both themes were checked visually rather than assumed.
- The banner uses only `<pattern>` and `<radialGradient>` — no filters or `foreignObject` — confirmed rendering correctly in a browser.

## Deliberately omitted

- **npm badge** — `package.json` is `"private": true`; distribution is via the shadcn registry.
- **Release badge** — `github/release` returns `{"error":"not found"}`, as the repo has no releases.

## Drive-by fix

The old sponsor badge passed `color=#fe8e86` to shields.io, which expects a bare hex — the `#` broke the color. Replaced by the shieldcn sponsor badge.

## Judgment calls, easy to revert

- The `## 8bitcn/ui` heading is now the banner (the convention shadcn/ui itself follows); the title lives in the image `alt` text for accessibility.
- The shields.io sponsor badge was swapped for a shieldcn one so the row is visually consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README header with refreshed branding and a centered logo.
  * Added badges and links for repository activity, community, licensing, documentation, components, themes, and sponsorship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->