### PR TITLE
fix(themes): sync theme and mode to the URL with nuqs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,9 @@ import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { Suspense } from "react";
 import { ActiveThemeProvider } from "@/components/active-theme";
+import { ModeUrlSync } from "@/components/mode-url-sync";
 import { ScreenSize } from "@/components/screen-size";
 import SearchDialog from "@/components/search";
 import SiteFooter from "@/components/site-footer";
@@ -52,6 +54,9 @@ export default function RootLayout({
               enableSystem
             >
               <ActiveThemeProvider>
+                <Suspense fallback={null}>
+                  <ModeUrlSync />
+                </Suspense>
                 <SiteHeader />
                 <div className="mx-auto w-full max-w-[1400px] flex-1 border-r border-l border-dashed">
                   {children}

--- a/components/active-theme.tsx
+++ b/components/active-theme.tsx
@@ -6,6 +6,7 @@ import {
   createContext,
   type ReactNode,
   Suspense,
+  useCallback,
   useContext,
   useEffect,
   useRef,
@@ -44,14 +45,24 @@ export function ActiveThemeProvider({
 }) {
   const pathname = usePathname();
 
-  const [activeTheme, setActiveTheme] = useState<Theme>(
+  const [activeTheme, setActiveThemeState] = useState<Theme>(
     () => initialTheme || DEFAULT_THEME
   );
+
+  // Only themes the visitor picked belong in the URL, so that a link can be
+  // copied and shared. Resets on navigation deliberately leave it alone.
+  const [selectedTheme, setSelectedTheme] = useState<Theme | null>(null);
+
+  const setActiveTheme = useCallback((theme: Theme) => {
+    setActiveThemeState(theme);
+    setSelectedTheme(theme);
+  }, []);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: "We want to reset the theme on pathname change"
   useEffect(() => {
     queueMicrotask(() => {
-      setActiveTheme(DEFAULT_THEME);
+      setActiveThemeState(DEFAULT_THEME);
+      setSelectedTheme(null);
     });
   }, [pathname]);
 
@@ -76,7 +87,10 @@ export function ActiveThemeProvider({
       <Suspense
         fallback={<span className="sr-only">Loading theme preference</span>}
       >
-        <ActiveThemeUrlSync />
+        <ActiveThemeUrlSync
+          onUrlTheme={setActiveThemeState}
+          selectedTheme={selectedTheme}
+        />
       </Suspense>
       {children}
     </ThemeContext.Provider>
@@ -96,28 +110,45 @@ export function useThemeConfig() {
 export const useUrlTheme = () =>
   useQueryState("theme", parseAsStringLiteral(Object.values(Theme)));
 
-// Load the active theme from the URL query parameter on mount.
-export function ActiveThemeUrlSync() {
-  const [urlTheme] = useUrlTheme();
+// Keeps the active theme and the `theme` query parameter in step, so a theme
+// can be shared by copying the URL. Kept in its own component because reading
+// the query string suspends, and the provider itself wraps the whole app.
+function ActiveThemeUrlSync({
+  onUrlTheme,
+  selectedTheme,
+}: {
+  onUrlTheme: (theme: Theme) => void;
+  selectedTheme: Theme | null;
+}) {
+  const [urlTheme, setUrlTheme] = useUrlTheme();
   const synced = useRef(false);
-  const { activeTheme, setActiveTheme } = useThemeConfig();
 
+  // URL -> state, once on mount, so a shared link opens on the right theme.
   useEffect(() => {
-    if (synced.current || !urlTheme) {
+    if (synced.current) {
       return;
-    }
-    if (urlTheme !== activeTheme) {
-      // Setting it directly here would be cancelled by the useEffect above
-      // that resets the theme on pathname change.
-      // Defer to the end of the microtask queue to re-apply it afterwards
-      // to follow the URL as the source of truth.
-      queueMicrotask(() => {
-        setActiveTheme(urlTheme);
-      });
     }
     // Avoid queuing multiple times
     synced.current = true;
-  }, [urlTheme, activeTheme, setActiveTheme]);
+
+    if (!urlTheme) {
+      return;
+    }
+    // Setting it directly here would be cancelled by the useEffect above
+    // that resets the theme on pathname change.
+    // Defer to the end of the microtask queue to re-apply it afterwards
+    // to follow the URL as the source of truth.
+    queueMicrotask(() => {
+      onUrlTheme(urlTheme);
+    });
+  }, [urlTheme, onUrlTheme]);
+
+  // State -> URL, so picking a theme anywhere produces a shareable link.
+  useEffect(() => {
+    if (selectedTheme) {
+      setUrlTheme(selectedTheme);
+    }
+  }, [selectedTheme, setUrlTheme]);
 
   return null;
 }

--- a/components/mode-url-sync.tsx
+++ b/components/mode-url-sync.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { parseAsStringLiteral, useQueryState } from "nuqs";
+import { useEffect, useRef } from "react";
+
+const MODES = ["light", "dark"] as const;
+
+type Mode = (typeof MODES)[number];
+
+const useUrlMode = () => useQueryState("mode", parseAsStringLiteral(MODES));
+
+/**
+ * Mirrors light / dark mode into the `mode` query parameter, so a copied URL
+ * carries it alongside the theme.
+ *
+ * This lives next to the mode switcher rather than inside it: the switcher is
+ * published through the registry, and wiring it to the URL would force every
+ * install to take on nuqs.
+ */
+export function ModeUrlSync() {
+  const [urlMode, setUrlMode] = useUrlMode();
+  const { setTheme, theme } = useTheme();
+  const applied = useRef(false);
+  const baseline = useRef<string | null>(null);
+
+  // URL -> next-themes, once, so a shared link opens in the right mode.
+  useEffect(() => {
+    if (applied.current) {
+      return;
+    }
+    applied.current = true;
+
+    if (urlMode && urlMode !== theme) {
+      setTheme(urlMode);
+    }
+  }, [urlMode, theme, setTheme]);
+
+  // next-themes -> URL, but only after the visitor actually switches modes.
+  // Writing on mount would append `?mode=` to every visit of anyone who has
+  // ever picked a mode, since next-themes restores that choice from storage.
+  useEffect(() => {
+    if (baseline.current === null) {
+      // next-themes reports `undefined` until it has mounted and read storage.
+      if (theme === undefined) {
+        return;
+      }
+      baseline.current = theme;
+      return;
+    }
+
+    if (theme && theme !== baseline.current && theme !== "system") {
+      setUrlMode(theme as Mode);
+    }
+  }, [theme, setUrlMode]);
+
+  return null;
+}

--- a/components/profile-creator.tsx
+++ b/components/profile-creator.tsx
@@ -4,7 +4,7 @@
 import * as htmlToImage from "html-to-image";
 import { parseAsBoolean, parseAsString, useQueryStates } from "nuqs";
 import { useMemo, useState } from "react";
-import { useThemeConfig, useUrlTheme } from "@/components/active-theme";
+import { useThemeConfig } from "@/components/active-theme";
 import { SelectThemeDropdown } from "@/components/select-theme-dropdown";
 import { Button } from "@/components/ui/8bit/button";
 import {
@@ -339,7 +339,6 @@ export default function ProfileCard() {
   };
 
   const { activeTheme, setActiveTheme } = useThemeConfig();
-  const [, setUrlTheme] = useUrlTheme();
 
   return (
     <div className="retro space-y-6 p-4 md:p-6">
@@ -513,10 +512,7 @@ export default function ProfileCard() {
           <div className="mx-auto max-w-xs">
             <SelectThemeDropdown
               activeTheme={activeTheme}
-              setActiveTheme={(theme) => {
-                setActiveTheme(theme);
-                setUrlTheme(theme);
-              }}
+              setActiveTheme={setActiveTheme}
             />
           </div>
           <div className="flex justify-center p-5" id="profile-card">

--- a/registry.json
+++ b/registry.json
@@ -1881,6 +1881,7 @@
       "title": "8-bit Theme Selector",
       "description": "A complete theme selector component with dropdown selection and code copy functionality. Includes theme context provider for managing active themes across the application.",
       "registryDependencies": ["select"],
+      "dependencies": ["nuqs"],
       "files": [
         {
           "path": "components/select-theme-dropdown.tsx",


### PR DESCRIPTION
Picking a theme applied it but never touched the URL, so a theme could not be shared by copying the link.

## The cause

The URL was only ever read, never written. `ActiveThemeUrlSync` loaded `?theme=` on mount, but `setActiveTheme` just set React state.

The profile creator had worked around this at its own call site:

```tsx
setActiveTheme={(theme) => {
  setActiveTheme(theme);
  setUrlTheme(theme);   // only here
}}
```

So the profile creator was the one place it worked, and every other selector — the landing page showcase, `/themes`, the theme grid, the docs examples — was silently out of sync.

## The fix

Move the write into `ActiveThemeProvider`'s `setActiveTheme`, so every selector stays in step with the URL by construction, and drop the local workaround.

Resets on navigation deliberately stay out of the URL, so browsing between pages doesn't append `?theme=default`. That's why picked themes are tracked separately from the active one, rather than just mirroring `activeTheme` into the query string.

## Also: light/dark in the URL

So a copied link carries the whole look, not just half of it. This lives in a new app-level `ModeUrlSync` rather than in `RetroModeSwitcher`, because the switcher **ships through the registry** — wiring it to the URL would force every install to take on nuqs and a `NuqsAdapter`. It only writes once the visitor actually switches modes, so a plain visit isn't given a `?mode=` it didn't ask for.

## Drive-by: broken registry entry

The `theme-selector` entry ships `active-theme.tsx`, which imports nuqs, but never declared it. Anyone running `shadcn add @8bitcn/theme-selector` got a component importing a package they had no reason to have installed. Added `"dependencies": ["nuqs"]`. This change makes nuqs more load-bearing there, so it's worth fixing alongside.

## Verification

Reproduced the bug first (theme applied, `location.search` empty), then confirmed against a dev server:

| Check | Result |
|---|---|
| Landing page selector | `?theme=gameboy` written |
| `/themes` selector | `?theme=zelda` written |
| Shared link opens correctly | `?theme=dragon-hoard` → `theme-dragon-hoard`, dropdown reads "Dragon Hoard" |
| Mode toggle | `?theme=zelda&mode=dark` |
| URL beats stored preference | stored `dark` + `?mode=light` → renders light |
| Navigation stays clean | `/` → `/themes` adds no `?theme=default` |
| Plain visit stays clean | stored mode present, no `?mode=` appended |

`tsc --noEmit` clean, lint clean on all changed files, and `pnpm build` passes with `/`, `/themes` and the rest **still prerendered as static** — the new Suspense-wrapped nuqs hook in the root layout does not push pages into dynamic rendering.

## Note

`ActiveThemeUrlSync` is no longer exported; it now takes props and is an internal detail of the provider. Nothing else in the repo imported it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added URL synchronization for light/dark mode, allowing theme preferences to be shared through links.
  * Added URL synchronization for selected application themes.
  * Improved theme selection behavior when navigating between pages.

* **Bug Fixes**
  * Prevented theme settings from being overwritten during initial page loading.
  * Avoided unnecessary URL updates when restoring saved theme preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->