### PR TITLE
refactor(sponsors): remove Inbound as a sponsor

### DIFF
--- a/components/sponsors.tsx
+++ b/components/sponsors.tsx
@@ -60,12 +60,6 @@ const legendarySponsors = [
     image: "/sponsors/coolify-logo.png",
     invert: false,
   },
-  {
-    name: "Inbound",
-    url: "https://inbound.new/",
-    image: "/sponsors/inbound.svg",
-    invert: false,
-  },
 ];
 
 const sponsors = [


### PR DESCRIPTION
Removes Inbound from the **legendary** sponsor tier in [components/sponsors.tsx](components/sponsors.tsx).

## Scope

Follows how sponsors have been removed before — [#588](https://github.com/TheOrcDev/8bitcn-ui/pull/588) (shadcnspace) and [#553](https://github.com/TheOrcDev/8bitcn-ui/pull/553) (Inbox Zero) — which changed only `sponsors.tsx`:

- **Logo asset kept.** `public/sponsors/inbound.svg` stays, consistent with `bounty.jpg` and `shadcnspace.png`, which are both still in the repo after their sponsors were removed.
- **Placeholder count untouched.** The legendary tier still renders 4 "Be here" slots, exactly as #588 left it.

Worth noting for a future call, not changed here: the legendary and regular tiers each currently total 8 slots (4 sponsors + 4 placeholders, 1 + 7). This drops legendary to 7. Adding a sponsor has historically decremented the placeholder array to hold that total, but removing one has not incremented it — so I matched the removal precedent. Bumping the legendary placeholders to 5 would restore the 8-slot symmetry if that's the intent.

`inbound` appears nowhere else in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed Inbound from the legendary sponsors list.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->