### PR TITLE
fix(button-group): close the gaps between grouped buttons

### DIFF
--- a/components/ui/8bit/button-group.tsx
+++ b/components/ui/8bit/button-group.tsx
@@ -7,7 +7,6 @@ import {
   ButtonGroupText as ShadcnButtonGroupText,
   buttonGroupVariants,
 } from "@/components/ui/button-group";
-import { Separator } from "@/components/ui/8bit/separator";
 
 import "@/components/ui/8bit/styles/retro.css";
 
@@ -56,7 +55,13 @@ function ButtonGroup({
       <div className="absolute bottom-0 right-0 size-1.5 bg-foreground dark:bg-ring pointer-events-none z-10" />
 
       <ShadcnButtonGroup
-        className={cn(className)}
+        className={cn(
+          // The group draws one shared border, so the per-button pixel borders
+          // would double it up on the outer edges and paint across every
+          // junction.
+          "[&_[data-slot=button-decorations]]:hidden",
+          className
+        )}
         orientation={orientation}
         {...props}
       >
@@ -68,14 +73,18 @@ function ButtonGroup({
 
 // ─── ButtonGroupSeparator ────────────────────────────────────────────────────
 
-export type BitButtonGroupSeparatorProps = React.ComponentProps<
-  typeof Separator
->;
+export type BitButtonGroupSeparatorProps = React.ComponentProps<"div"> & {
+  orientation?: "horizontal" | "vertical";
+};
 
 /**
- * 8-bit ButtonGroupSeparator renders a pixel-art dashed divider between items.
- * Wraps the 8-bit Separator component (which uses a pixel-dash background pattern).
+ * 8-bit ButtonGroupSeparator renders a solid pixel divider between items.
  * Defaults to `orientation="vertical"` for use inside a horizontal ButtonGroup.
+ *
+ * This deliberately does not reuse the 8-bit Separator: that one paints a
+ * dashed pattern whose transparent segments would expose the page background
+ * through the group, reading as gaps between the buttons. It is also sized to
+ * the same 6px grid as the group's border rather than the Separator's 2px.
  */
 function ButtonGroupSeparator({
   className,
@@ -83,10 +92,16 @@ function ButtonGroupSeparator({
   ...props
 }: BitButtonGroupSeparatorProps) {
   return (
-    <Separator
+    <div
+      aria-orientation={orientation}
+      className={cn(
+        "shrink-0 self-stretch bg-foreground dark:bg-ring",
+        orientation === "vertical" ? "w-1.5" : "h-1.5",
+        className
+      )}
+      data-orientation={orientation}
       data-slot="button-group-separator"
-      orientation={orientation}
-      className={cn("relative m-0! self-stretch", className)}
+      role="separator"
       {...props}
     />
   );

--- a/components/ui/8bit/button.tsx
+++ b/components/ui/8bit/button.tsx
@@ -48,7 +48,11 @@ interface ButtonDecorationsProps {
 
 function ButtonDecorations({ size, variant }: ButtonDecorationsProps) {
   return (
-    <span aria-hidden="true" className="pointer-events-none contents">
+    <span
+      aria-hidden="true"
+      className="pointer-events-none contents"
+      data-slot="button-decorations"
+    >
       {variant !== "ghost" && variant !== "link" && size !== "icon" && (
         <>
           {/* Pixelated border */}


### PR DESCRIPTION
Grouped buttons showed white notches at the top and bottom of every junction.


## Cause

`ButtonGroupSeparator` wrapped the 8-bit `Separator`, which paints a **dashed pattern, not a solid line**:

```
background-size:  2px 16px
background-image: linear-gradient(0deg, var(--foreground) 75%, transparent 75%)
```

The top 25% of every 16px tile is transparent. At height 36 that puts transparent bands at y = 0–4, 16–20 and 32–36.

Nothing else paints that 2px column at the group's edges:

- the group's shared border sits **outside** the box (y −6–0 and 36–42)
- each button's vertical side bar is `top-1.5 h-[calc(100%-12px)]` → **y 6–30 only**
- each button's corner squares sit **inside its own box** (x 84–90 and 92–98), never over the x 90–92 column

So y 16–20 was covered by the side bars, but **y 0–4 and y 32–36 were covered by nothing** and the page background showed through — exactly two notches per junction, top and bottom.

Groups without a separator were never affected, since adjacent buttons' corner squares meet.

## Fix

**1. Render the divider directly instead of reusing the dashed `Separator`.** Also sized to the same 6px grid as the group's border, rather than the Separator's off-grid 2px. (Overriding the Separator in place would not have worked cleanly — its gradient comes from `data-[orientation=vertical]:bg-[…]`, which outranks a plain `bg-foreground`.)

**2. Hide the per-button pixel borders inside a group.** [#596](https://github.com/TheOrcDev/8bitcn-ui/pull/596) intended this — its commit message says *"fix(button): hide pixel borders when rendered inside button-group"* — but it never landed: `button.tsx` was unchanged and no rule suppressed them. Every child button was drawing its full border underneath the group's shared one, doubling the outer edges and painting 6px into its neighbour at every junction.

The decorations wrapper now carries `data-slot="button-decorations"` (purely additive) so the group can hide it. I avoided keying off `span[aria-hidden="true"]`, which would also hide legitimate icon spans in consumers' buttons.

## Verification

Reproduced first on the deployed page, then confirmed against a dev build:

- **Before:** probing the separator column hit nothing at the top and bottom bands. Forcing the separators solid in the live DOM made every notch disappear — confirming causation rather than inferring it.
- **After:** the separator column is opaque at every y from 1 to 35; a 3× magnified render shows continuous top and bottom edges.
- **All 10 groups on the docs page, light and dark:** every separator is `background-image: none` and opaque; every child's decorations are `display: none`.
- **Both orientations:** horizontal separators render 6×36, the vertical group's render 119×6.

`pnpm check` clean (122 files), `tsc --noEmit` clean, `pnpm build` passes with all pages still prerendered static.

## Note

`button.tsx` and `button-group.tsx` are both registry-distributed. The change to `button.tsx` is one additive `data-slot` attribute, and no registry entry needed updating — `@8bitcn/button-group` already ships both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved 8-bit button group dividers with consistent solid-pixel styling.
  - Prevented duplicate decorative borders within grouped buttons for a cleaner appearance.
  - Improved accessibility metadata for button group separators.
- **Style**
  - Added internal labeling for button decorations to support consistent component styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->