### PR TITLE
fix(blocks): improve mobile Brick Breaker controls

### DIFF
--- a/components/ui/8bit/blocks/not-found-brick-breaker.test.tsx
+++ b/components/ui/8bit/blocks/not-found-brick-breaker.test.tsx
@@ -312,7 +312,7 @@ describe("NotFoundBrickBreaker", () => {
     expect(paddleCalls.at(-1)?.[0]).toBe(204);
   });
 
-  it("keeps captured drag control across pointer leave and releases it", () => {
+  it("starts, launches, and keeps captured thumb drag control", () => {
     render(<NotFoundBrickBreaker />);
     const playfield = screen.getByTestId("brick-breaker-playfield");
     const capturedPointers = new Set<number>();
@@ -350,14 +350,16 @@ describe("NotFoundBrickBreaker", () => {
         value: setPointerCapture,
       },
     });
-    fireEvent.click(screen.getByRole("button", { name: "START GAME" }));
-
     fireEvent.pointerDown(playfield, {
       button: 0,
       clientX: 0,
       pointerId: 7,
       pointerType: "touch",
     });
+    expect(screen.getByText("PLAYING")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "PAUSE" })).toBeTruthy();
+    expect(frameCallbacks.size).toBe(1);
+
     fireEvent.pointerLeave(playfield, {
       pointerId: 7,
       pointerType: "touch",
@@ -417,49 +419,20 @@ describe("NotFoundBrickBreaker", () => {
     expect(paddleCalls.at(-1)?.[0]).toBeGreaterThan(204);
   });
 
-  it("hands control from pointer hover to an explicit direction button", () => {
+  it("does not render explicit direction buttons", () => {
     render(<NotFoundBrickBreaker />);
-    const playfield = screen.getByTestId("brick-breaker-playfield");
-    fireEvent.click(screen.getByRole("button", { name: "START GAME" }));
-    fireEvent.click(screen.getByRole("button", { name: "LAUNCH" }));
-    Object.defineProperty(playfield, "getBoundingClientRect", {
-      configurable: true,
-      value: () =>
-        ({
-          bottom: 320,
-          height: 320,
-          left: 0,
-          right: 480,
-          top: 0,
-          width: 480,
-          x: 0,
-          y: 0,
-        }) as DOMRect,
-    });
-    fireEvent.pointerMove(playfield, {
-      clientX: 0,
-      pointerId: 1,
-      pointerType: "mouse",
-    });
-    vi.mocked(canvasContext.fillRect).mockClear();
 
-    const rightButton = screen.getByRole("button", {
-      name: "Move paddle right",
-    });
-    fireEvent.pointerDown(rightButton, { button: 0, pointerId: 9 });
-    runNextFrame(0);
-    runNextFrame(50);
-    fireEvent.pointerUp(rightButton, { button: 0, pointerId: 9 });
-
-    const paddleCalls = vi
-      .mocked(canvasContext.fillRect)
-      .mock.calls.filter((call) => call[2] === 72 && call[3] === 8);
-    expect(paddleCalls.at(-1)?.[0]).toBeGreaterThan(204);
+    expect(
+      screen.queryByRole("button", { name: "Move paddle left" })
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Move paddle right" })
+    ).toBeNull();
   });
 
-  it("uses the same held movement for keyboard and explicit controls", () => {
+  it("keeps held keyboard movement after removing direction buttons", () => {
     render(<NotFoundBrickBreaker />);
-    let playfield = screen.getByTestId("brick-breaker-playfield");
+    const playfield = screen.getByTestId("brick-breaker-playfield");
     fireEvent.click(screen.getByRole("button", { name: "START GAME" }));
     fireEvent.click(screen.getByRole("button", { name: "LAUNCH" }));
     vi.mocked(canvasContext.fillRect).mockClear();
@@ -468,36 +441,12 @@ describe("NotFoundBrickBreaker", () => {
     runNextFrame(0);
     runNextFrame(50);
     fireEvent.keyUp(playfield, { key: "ArrowLeft" });
-    let paddleCalls = vi
+    const paddleCalls = vi
       .mocked(canvasContext.fillRect)
       .mock.calls.filter((call) => call[2] === 72 && call[3] === 8);
     const keyboardPaddleX = paddleCalls.at(-1)?.[0];
 
-    cleanup();
-    frameCallbacks.clear();
-    canvasContext = createCanvasContext();
-    render(<NotFoundBrickBreaker />);
-    playfield = screen.getByTestId("brick-breaker-playfield");
-    fireEvent.click(screen.getByRole("button", { name: "START GAME" }));
-    fireEvent.click(screen.getByRole("button", { name: "LAUNCH" }));
-    vi.mocked(canvasContext.fillRect).mockClear();
-
-    const leftButton = screen.getByRole("button", {
-      name: "Move paddle left",
-    });
-    expect(fireEvent.pointerDown(leftButton, { button: 0, pointerId: 9 })).toBe(
-      false
-    );
-    runNextFrame(0);
-    runNextFrame(50);
-    fireEvent.pointerUp(leftButton, { button: 0, pointerId: 9 });
-    paddleCalls = vi
-      .mocked(canvasContext.fillRect)
-      .mock.calls.filter((call) => call[2] === 72 && call[3] === 8);
-    const explicitControlPaddleX = paddleCalls.at(-1)?.[0];
-
     expect(keyboardPaddleX).toBeLessThan(204);
-    expect(explicitControlPaddleX).toBe(keyboardPaddleX);
     expect(document.activeElement).toBe(playfield);
   });
 

--- a/components/ui/8bit/blocks/not-found-brick-breaker.tsx
+++ b/components/ui/8bit/blocks/not-found-brick-breaker.tsx
@@ -596,6 +596,10 @@ export function NotFoundBrickBreaker({
     event.currentTarget.setPointerCapture?.(event.pointerId);
     updatePointerPosition(event);
 
+    if (engineRef.current.phase === "idle" && event.pointerType !== "mouse") {
+      startGame();
+      updatePointerPosition(event);
+    }
     if (engineRef.current.phase === "ready") {
       launchGame();
     }
@@ -678,26 +682,7 @@ export function NotFoundBrickBreaker({
     }
   };
 
-  const setDirection = (
-    direction: "left" | "right",
-    pressed: boolean
-  ): void => {
-    const canMove =
-      engineRef.current.phase === "ready" ||
-      engineRef.current.phase === "playing";
-    if (pressed) {
-      inputRef.current.pointerX = null;
-    }
-    inputRef.current[direction] = pressed && canMove;
-
-    if (pressed && engineRef.current.phase === "ready") {
-      advanceBrickBreaker(engineRef.current, inputRef.current, 1 / 30);
-      renderCanvas();
-    }
-  };
-
   const actionLabel = ACTION_LABELS[hud.phase];
-  const canMove = hud.phase === "ready" || hud.phase === "playing";
 
   return (
     <section
@@ -769,7 +754,8 @@ export function NotFoundBrickBreaker({
               id={instructionsId}
             >
               <p className="text-muted-foreground text-xs">
-                Move the paddle, launch the ball, and clear all 30 bricks.
+                Touch and drag on the playfield to move the paddle. Your first
+                touch starts and launches the ball.
               </p>
               <KbdGroup className="hidden flex-wrap justify-center sm:inline-flex">
                 <Kbd>LEFT</Kbd>
@@ -786,61 +772,17 @@ export function NotFoundBrickBreaker({
             </div>
           </CardContent>
 
-          <CardFooter className="flex flex-wrap justify-center gap-4 px-4 pb-5">
+          <CardFooter className="grid grid-cols-2 gap-3 px-4 pb-5 sm:flex sm:justify-center sm:gap-4">
             <Button
-              aria-label="Move paddle left"
-              className="min-h-11 min-w-24 motion-reduce:transition-none"
-              disabled={!canMove}
-              onKeyDown={(event) => {
-                if (event.key === " " || event.key === "Enter") {
-                  setDirection("left", true);
-                }
-              }}
-              onKeyUp={() => setDirection("left", false)}
-              onPointerCancel={() => setDirection("left", false)}
-              onPointerDown={(event) => {
-                event.preventDefault();
-                setDirection("left", true);
-              }}
-              onPointerLeave={() => setDirection("left", false)}
-              onPointerUp={() => setDirection("left", false)}
-              type="button"
-              variant="outline"
-            >
-              LEFT
-            </Button>
-            <Button
-              className="min-h-11 min-w-32 motion-reduce:transition-none"
+              className="min-h-11 w-full motion-reduce:transition-none sm:w-auto sm:min-w-32"
               onClick={primaryAction}
               type="button"
             >
               {actionLabel}
             </Button>
             <Button
-              aria-label="Move paddle right"
-              className="min-h-11 min-w-24 motion-reduce:transition-none"
-              disabled={!canMove}
-              onKeyDown={(event) => {
-                if (event.key === " " || event.key === "Enter") {
-                  setDirection("right", true);
-                }
-              }}
-              onKeyUp={() => setDirection("right", false)}
-              onPointerCancel={() => setDirection("right", false)}
-              onPointerDown={(event) => {
-                event.preventDefault();
-                setDirection("right", true);
-              }}
-              onPointerLeave={() => setDirection("right", false)}
-              onPointerUp={() => setDirection("right", false)}
-              type="button"
-              variant="outline"
-            >
-              RIGHT
-            </Button>
-            <Button
               asChild
-              className="min-h-11 motion-reduce:transition-none"
+              className="min-h-11 w-full motion-reduce:transition-none sm:w-auto"
               variant="secondary"
             >
               <Link href={href}>{cta}</Link>

--- a/content/docs/blocks/layout/not-found-brick-breaker.mdx
+++ b/content/docs/blocks/layout/not-found-brick-breaker.mdx
@@ -60,10 +60,12 @@ the 404 response when it is used from `app/not-found.tsx`.
 | P or Escape | Pause or resume |
 | R | Restart after winning or losing |
 | Pointer move or drag | Position the paddle |
-| LEFT, center action, RIGHT buttons | Touch controls; the center action follows the current phase |
+| Touch and drag on the playfield | Start and launch with the first touch, then position the paddle |
+| Center action button | Start, launch, pause, resume, or restart for the current phase |
 
 Keyboard handling is scoped to the focused playfield. Pointer capture and
-`touch-action` are limited to the playfield rather than the whole page.
+`touch-action` are limited to the playfield rather than the whole page, so the
+game can be played directly with one thumb without separate direction buttons.
 
 ## Scoring
 


### PR DESCRIPTION
## Summary

- remove the separate LEFT and RIGHT Brick Breaker buttons
- let the first touch start and launch the game, then keep the paddle under a captured thumb drag
- make the remaining phase action and Home controls two 44px mobile targets
- update regression coverage and control documentation

## Verification

- Shadscan: 92/100 baseline and 92/100 pre-commit
- `pnpm check`: passed (133 files)
- Vitest: 100 tests passed; Brick Breaker suite 20 tests passed
- TypeScript: passed
- shadcn registry build: passed
- Next.js production build: passed (291 pages)
- rendered at 390×844: no horizontal overflow, 324×216 playfield, 156×44 action targets, clean console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Start the Brick Breaker game by touching the playfield.
  - Drag on the playfield to move the paddle during touch play.
  - Removed the separate left and right paddle-control buttons.
  - Updated footer actions with responsive full-width sizing.
  - The center action button now adapts to the game’s current state.

- **Documentation**
  - Updated controls guidance to explain touch dragging and first-touch launch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->