### PR TITLE
fix(blocks): sync game palettes with dark mode

### DIFF
--- a/components/ui/8bit/blocks/not-found-brick-breaker.test.tsx
+++ b/components/ui/8bit/blocks/not-found-brick-breaker.test.tsx
@@ -83,6 +83,47 @@ afterEach(() => {
 });
 
 describe("NotFoundBrickBreaker", () => {
+  it("paints from the playfield palette instead of document-level colors", () => {
+    const rootPalette: Readonly<Record<string, string>> = {
+      "--accent": "root-accent",
+      "--background": "root-background",
+      "--border": "root-border",
+      "--foreground": "root-foreground",
+      "--muted": "root-muted",
+      "--primary": "root-primary",
+      "--secondary": "root-secondary",
+    };
+    const playfieldPalette: Readonly<Record<string, string>> = {
+      "--accent": "playfield-accent",
+      "--background": "playfield-background",
+      "--border": "playfield-border",
+      "--foreground": "playfield-foreground",
+      "--muted": "playfield-muted",
+      "--primary": "playfield-primary",
+      "--secondary": "playfield-secondary",
+    };
+    const paintedRects: Array<{ fillStyle: string }> = [];
+
+    vi.spyOn(window, "getComputedStyle").mockImplementation((element) => {
+      const palette =
+        element instanceof HTMLCanvasElement ? playfieldPalette : rootPalette;
+
+      return {
+        getPropertyValue: (token: string) => palette[token] ?? "",
+      } as CSSStyleDeclaration;
+    });
+    vi.mocked(canvasContext.fillRect).mockImplementation(() => {
+      paintedRects.push({ fillStyle: String(canvasContext.fillStyle) });
+    });
+
+    render(<NotFoundBrickBreaker />);
+
+    expect(paintedRects[0]?.fillStyle).toBe("playfield-background");
+    expect(
+      paintedRects.some(({ fillStyle }) => fillStyle === "root-background")
+    ).toBe(false);
+  });
+
   it("renders the complete non-canvas 404 experience before play", () => {
     const view = render(<NotFoundBrickBreaker />);
     const playfield = screen.getByTestId("brick-breaker-playfield");

--- a/components/ui/8bit/blocks/not-found-brick-breaker.tsx
+++ b/components/ui/8bit/blocks/not-found-brick-breaker.tsx
@@ -123,8 +123,8 @@ function getCssColor(
   return styles.getPropertyValue(token).trim() || fallback;
 }
 
-function readCanvasColors(): CanvasColors {
-  const styles = getComputedStyle(document.documentElement);
+function readCanvasColors(source: Element): CanvasColors {
+  const styles = getComputedStyle(source);
   return {
     accent: getCssColor(styles, "--accent", "Highlight"),
     background: getCssColor(styles, "--background", "Canvas"),
@@ -520,7 +520,7 @@ export function NotFoundBrickBreaker({
       if (!canvasRef.current) {
         return;
       }
-      colorsRef.current = readCanvasColors();
+      colorsRef.current = readCanvasColors(canvasRef.current);
       configureCanvas(canvasRef.current);
       renderCanvas();
     };

--- a/content/docs/blocks/layout/not-found-brick-breaker.mdx
+++ b/content/docs/blocks/layout/not-found-brick-breaker.mdx
@@ -83,6 +83,12 @@ wall adds a 104-point route bonus, so a successful run ends at exactly 404.
 | `href` | `string` | `/` |
 | `className` | `string` | None |
 
+## Theme Behavior
+
+The playfield samples color tokens from its own themed surface, so light and
+dark modes invert the canvas together with the surrounding block. Scoped color
+themes are supported; the canvas refreshes when the root theme or mode changes.
+
 ## Accessibility
 
 The canvas is supplementary. The 404 heading, score, lives, phase, instructions,

--- a/content/docs/blocks/layout/not-found-crate-pusher.mdx
+++ b/content/docs/blocks/layout/not-found-crate-pusher.mdx
@@ -136,6 +136,12 @@ const level = [
 | `seed` | `number` | `undefined` (create a runtime seed on Start Shift) |
 | `className` | `string` | None |
 
+## Theme Behavior
+
+The board uses inherited semantic color tokens, so its floor, walls, portals,
+crates, and courier invert with light and dark mode and follow scoped color
+themes.
+
 ## Accessibility
 
 The 404 heading, counters, instructions, state, controls, and Home link are DOM


### PR DESCRIPTION
## Summary

- make Brick Breaker sample theme tokens from its rendered canvas surface instead of the document root
- keep colored themes synchronized when switching between light and dark mode
- add regression coverage and document theme behavior for both 404 games

## Verification

- `pnpm test` — 101 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm check`
- `pnpm build`
- `shadcn build`
- Shadscan: 92/100 baseline → 92/100 final
- Browser QA: Brick Breaker and Crate Pusher in Sega light and dark modes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved themed color handling for the Brick Breaker playfield, including support for scoped themes and theme changes.

* **Documentation**
  * Added guidance on theme behavior for the Brick Breaker and Crate Pusher blocks.
  * Documented support for light, dark, and inherited color themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->