### PR TITLE
Add 8bit showcase loading skeletons

### DIFF
--- a/components/examples/home-component-showcase-skeleton.tsx
+++ b/components/examples/home-component-showcase-skeleton.tsx
@@ -1,0 +1,63 @@
+import { Skeleton } from "@/components/ui/8bit/skeleton";
+
+function ColumnOneSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-40 w-full" />
+      <Skeleton className="h-52 w-full" />
+      <Skeleton className="h-28 w-full" />
+      <Skeleton className="h-28 w-full" />
+      <Skeleton className="h-40 w-full" />
+      <Skeleton className="h-72 w-full" />
+    </div>
+  );
+}
+
+function FeatureColumnSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 lg:col-span-2">
+      <Skeleton className="h-72 w-full" />
+      <Skeleton className="h-40 w-full" />
+      <Skeleton className="h-52 w-full" />
+      <Skeleton className="h-72 w-full" />
+      <Skeleton className="h-80 w-full" />
+    </div>
+  );
+}
+
+function InteractiveColumnSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Skeleton className="hidden h-12 w-full md:block" />
+      <Skeleton className="h-12 w-full" />
+      <Skeleton className="h-12 w-full" />
+      <Skeleton className="h-20 w-full" />
+      <Skeleton className="h-56 w-full" />
+      <Skeleton className="h-44 w-full" />
+      <Skeleton className="h-28 w-full" />
+      <Skeleton className="h-28 w-full" />
+    </div>
+  );
+}
+
+function HomeComponentShowcaseSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      className="mt-10 grid min-h-[800px] grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"
+      data-testid="home-showcase-skeleton"
+    >
+      <ColumnOneSkeleton />
+      <FeatureColumnSkeleton />
+      <InteractiveColumnSkeleton />
+    </div>
+  );
+}
+
+export {
+  ColumnOneSkeleton,
+  FeatureColumnSkeleton,
+  HomeComponentShowcaseSkeleton,
+  InteractiveColumnSkeleton,
+};

--- a/components/examples/home-component-showcase.test.tsx
+++ b/components/examples/home-component-showcase.test.tsx
@@ -47,9 +47,12 @@ afterEach(() => {
 });
 
 describe("HomeComponentShowcase", () => {
-  it("keeps a stable placeholder until all three columns are activated", async () => {
+  it("keeps an 8bit skeleton visible until all three columns are activated", async () => {
     const view = render(<HomeComponentShowcase />);
-    expect(view.container.querySelector(".min-h-\\[800px\\]")).toBeTruthy();
+    expect(screen.getByTestId("home-showcase-skeleton")).toBeTruthy();
+    expect(
+      view.container.querySelectorAll('[data-slot="skeleton"]').length
+    ).toBeGreaterThan(0);
     expect(view.container.firstElementChild?.hasAttribute("aria-busy")).toBe(
       false
     );
@@ -63,6 +66,7 @@ describe("HomeComponentShowcase", () => {
     expect(screen.getByText("Column one")).toBeTruthy();
     expect(screen.getByText("Feature column")).toBeTruthy();
     expect(screen.getByText("Interactive column")).toBeTruthy();
+    expect(screen.queryByTestId("home-showcase-skeleton")).toBeNull();
     expect(view.container.querySelector(".lg\\:grid-cols-4")).toBeTruthy();
     expect(view.container.firstElementChild?.hasAttribute("aria-busy")).toBe(
       false

--- a/components/examples/home-component-showcase.tsx
+++ b/components/examples/home-component-showcase.tsx
@@ -3,6 +3,12 @@
 import dynamic from "next/dynamic";
 import { useCallback, useRef, useState } from "react";
 
+import {
+  ColumnOneSkeleton,
+  FeatureColumnSkeleton,
+  HomeComponentShowcaseSkeleton,
+  InteractiveColumnSkeleton,
+} from "@/components/examples/home-component-showcase-skeleton";
 import { useNearViewport } from "@/hooks/use-near-viewport";
 import { useShowcaseScrollGuard } from "@/hooks/use-showcase-scroll-guard";
 
@@ -11,21 +17,21 @@ const ColumnOne = dynamic(
     import("./component-showcase/column-one").then(
       (module) => module.ColumnOne
     ),
-  { ssr: false }
+  { loading: ColumnOneSkeleton, ssr: false }
 );
 const FeatureColumn = dynamic(
   () =>
     import("./component-showcase/feature-column").then(
       (module) => module.FeatureColumn
     ),
-  { ssr: false }
+  { loading: FeatureColumnSkeleton, ssr: false }
 );
 const InteractiveColumn = dynamic(
   () =>
     import("./component-showcase/interactive-column").then(
       (module) => module.InteractiveColumn
     ),
-  { ssr: false }
+  { loading: InteractiveColumnSkeleton, ssr: false }
 );
 
 export default function HomeComponentShowcase() {
@@ -64,7 +70,7 @@ export default function HomeComponentShowcase() {
           <InteractiveColumn onReady={markInteractiveColumnReady} />
         </div>
       ) : (
-        <div className="mt-10 min-h-[800px]" />
+        <HomeComponentShowcaseSkeleton />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

The lazy-loaded homepage showcase previously reserved blank space until it neared the viewport, then swapped in three client-only columns with no loading fallback. That made the section appear abruptly and did not match 8bitcn's visual language.

- render a responsive 1–2–1 showcase placeholder using the existing 8bitcn `Skeleton`
- reuse matching column skeletons as each dynamic chunk's loading fallback
- add regression coverage for the skeleton-to-showcase transition

## Impact

Visitors now see a stable retro loading state instead of a blank gap or abrupt content pop. The layout remains responsive without horizontal overflow at 390px.

## Validation

- `pnpm test` — 132 tests passed
- `pnpm exec tsc --noEmit` — passed
- `pnpm build` — passed
- scoped Ultracite check — passed
- Shadscan — 92/100 (baseline matched)
- desktop and mobile browser QA — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive loading placeholders for standard, featured, and interactive showcase content.
  * Improved loading presentation with an accessible, identifiable skeleton layout.

* **Bug Fixes**
  * Replaced the previous empty loading placeholder with a structured showcase skeleton.
  * Skeleton content now disappears once all showcase columns finish loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->