### PR TITLE
Center active documentation sidebar items

### DIFF
--- a/components/blocks-sidebar.tsx
+++ b/components/blocks-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { TOP_LEVEL_SECTIONS } from "@/config/nav-items";
+import { useCenterActiveSidebarItem } from "@/hooks/use-center-active-sidebar-item";
 import type { source } from "@/lib/source";
 
 import { ScrollArea } from "./ui/scroll-area";
@@ -42,6 +43,7 @@ export function BlocksSidebar({
   ...props
 }: React.ComponentProps<typeof Sidebar> & { tree: typeof source.pageTree }) {
   const pathname = usePathname();
+  const { activeItemRef, viewportRef } = useCenterActiveSidebarItem(pathname);
 
   // Find the blocks folder in the tree
   const blocksFolder = tree.children.find(
@@ -58,7 +60,7 @@ export function BlocksSidebar({
       {...props}
     >
       <SidebarContent className="no-scrollbar overflow-x-hidden px-2">
-        <ScrollArea className="h-[calc(90svh-50px)]">
+        <ScrollArea className="h-[calc(90svh-50px)]" viewportRef={viewportRef}>
           <div className="sticky -top-1 z-10 h-8 shrink-0 bg-linear-to-b from-background via-background/80 to-background/50 blur-xs" />
           <SidebarGroup>
             <SidebarGroupLabel className="font-medium text-muted-foreground">
@@ -66,24 +68,32 @@ export function BlocksSidebar({
             </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {TOP_LEVEL_SECTIONS.map(({ name, href }) => (
-                  <SidebarMenuItem key={name}>
-                    <SidebarMenuButton
-                      asChild
-                      className="relative h-[30px] 3xl:fixed:w-full w-fit 3xl:fixed:max-w-48 overflow-visible border border-transparent font-medium text-[0.8rem] after:absolute after:inset-x-0 after:-inset-y-1 after:z-0 after:rounded-md data-[active=true]:border-accent data-[active=true]:bg-accent"
-                      isActive={
-                        href === "/docs"
-                          ? pathname === href
-                          : pathname.startsWith(href)
-                      }
-                    >
-                      <Link href={href}>
-                        <span className="absolute inset-0 flex w-(--sidebar-width) bg-transparent" />
-                        {name}
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))}
+                {TOP_LEVEL_SECTIONS.map(({ name, href }) => {
+                  const isCurrentPage = pathname === href;
+                  const isSectionActive =
+                    href === "/docs"
+                      ? isCurrentPage
+                      : pathname.startsWith(href);
+
+                  return (
+                    <SidebarMenuItem key={name}>
+                      <SidebarMenuButton
+                        asChild
+                        className="relative h-[30px] 3xl:fixed:w-full w-fit 3xl:fixed:max-w-48 overflow-visible border border-transparent font-medium text-[0.8rem] after:absolute after:inset-x-0 after:-inset-y-1 after:z-0 after:rounded-md data-[active=true]:border-accent data-[active=true]:bg-accent"
+                        isActive={isSectionActive}
+                      >
+                        <Link
+                          aria-current={isCurrentPage ? "page" : undefined}
+                          href={href}
+                          ref={isCurrentPage ? activeItemRef : undefined}
+                        >
+                          <span className="absolute inset-0 flex w-(--sidebar-width) bg-transparent" />
+                          {name}
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
@@ -137,14 +147,20 @@ export function BlocksSidebar({
                             return null;
                           }
 
+                          const isActive = blockItem.url === pathname;
+
                           return (
                             <SidebarMenuItem key={blockItem.url}>
                               <SidebarMenuButton
                                 asChild
                                 className="relative h-[30px] 3xl:fixed:w-full w-fit 3xl:fixed:max-w-48 overflow-visible border border-transparent font-medium text-[0.8rem] after:absolute after:inset-x-0 after:-inset-y-1 after:z-0 after:rounded-md data-[active=true]:border-accent data-[active=true]:bg-accent"
-                                isActive={blockItem.url === pathname}
+                                isActive={isActive}
                               >
-                                <Link href={blockItem.url}>
+                                <Link
+                                  aria-current={isActive ? "page" : undefined}
+                                  href={blockItem.url}
+                                  ref={isActive ? activeItemRef : undefined}
+                                >
                                   <span className="absolute inset-0 flex w-(--sidebar-width) bg-transparent" />
                                   {blockItem.name}
                                 </Link>

--- a/components/docs-sidebar.test.tsx
+++ b/components/docs-sidebar.test.tsx
@@ -1,0 +1,336 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import type { Root } from "fumadocs-core/page-tree";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BlocksSidebar } from "@/components/blocks-sidebar";
+import { DocsSidebar } from "@/components/docs-sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+const navigation = vi.hoisted(() => ({
+  pathname: "/docs/components/radio-group",
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => navigation.pathname,
+}));
+
+const tree = {
+  name: "Docs",
+  children: [
+    {
+      $id: "root:components",
+      type: "folder",
+      name: "Components",
+      children: [
+        {
+          type: "page",
+          name: "Accordion",
+          url: "/docs/components/accordion",
+        },
+        {
+          type: "page",
+          name: "Card",
+          url: "/docs/components/card",
+        },
+        {
+          type: "page",
+          name: "Radio Group",
+          url: "/docs/components/radio-group",
+        },
+        {
+          type: "page",
+          name: "XP Bar",
+          url: "/docs/components/xp-bar",
+        },
+      ],
+    },
+  ],
+} satisfies Root;
+
+const blocksTree = {
+  name: "Docs",
+  children: [
+    {
+      $id: "root:blocks",
+      type: "folder",
+      name: "Blocks",
+      children: [
+        {
+          $id: "root:blocks/gaming",
+          type: "folder",
+          name: "gaming",
+          children: [
+            {
+              type: "page",
+              name: "Loading Screen",
+              url: "/docs/blocks/gaming/loading-screen",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+} satisfies Root;
+
+const scrollPositions = new WeakMap<HTMLElement, number>();
+const itemOffsets: Record<string, number> = {
+  "/docs/components": 0,
+  "/docs/components/accordion": 0,
+  "/docs/components/card": 300,
+  "/docs/components/radio-group": 600,
+  "/docs/components/xp-bar": 1000,
+  "/docs/blocks/gaming/loading-screen": 600,
+};
+let resizeCallback: ResizeObserverCallback | undefined;
+let viewportHeight = 400;
+
+function createRect(top: number, height: number): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left: 0,
+    right: 220,
+    top,
+    width: 220,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  };
+}
+
+beforeEach(() => {
+  navigation.pathname = "/docs/components/radio-group";
+  resizeCallback = undefined;
+  viewportHeight = 400;
+
+  class Observer {
+    constructor(callback: ResizeObserverCallback) {
+      resizeCallback = callback;
+    }
+
+    disconnect = vi.fn();
+    observe = vi.fn();
+    unobserve = vi.fn();
+  }
+
+  vi.stubGlobal("ResizeObserver", Observer);
+
+  vi.stubGlobal("matchMedia", () => ({
+    addEventListener: vi.fn(),
+    matches: false,
+    media: "",
+    onchange: null,
+    removeEventListener: vi.fn(),
+  }));
+
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function getBoundingClientRect(this: HTMLElement) {
+      if (this.dataset.slot === "scroll-area-viewport") {
+        return createRect(100, viewportHeight);
+      }
+
+      if (
+        this.dataset.active === "true" &&
+        this.getAttribute("href") === navigation.pathname
+      ) {
+        const viewport = document.querySelector<HTMLElement>(
+          '[data-slot="scroll-area-viewport"]'
+        );
+        const viewportScrollTop = viewport
+          ? (scrollPositions.get(viewport) ?? 0)
+          : 0;
+
+        return createRect(
+          100 + itemOffsets[navigation.pathname] - viewportScrollTop,
+          30
+        );
+      }
+
+      return createRect(0, 0);
+    }
+  );
+
+  Object.defineProperties(HTMLElement.prototype, {
+    clientHeight: {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.dataset.slot === "scroll-area-viewport"
+          ? viewportHeight
+          : 0;
+      },
+    },
+    scrollHeight: {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.dataset.slot === "scroll-area-viewport" ? 1000 : 0;
+      },
+    },
+    scrollTop: {
+      configurable: true,
+      get(this: HTMLElement) {
+        return scrollPositions.get(this) ?? 0;
+      },
+      set(this: HTMLElement, value: number) {
+        scrollPositions.set(this, value);
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("DocsSidebar", () => {
+  it("centers the current page in the sidebar without scrolling the document", () => {
+    const view = render(
+      <SidebarProvider>
+        <DocsSidebar tree={tree} />
+      </SidebarProvider>
+    );
+
+    const viewport = view.container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+
+    expect(screen.getByRole("link", { name: "Radio Group" })).toBeTruthy();
+    expect(viewport?.scrollTop).toBe(415);
+    expect(window.scrollY).toBe(0);
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it("marks the current documentation page for assistive technology", () => {
+    render(
+      <SidebarProvider>
+        <DocsSidebar tree={tree} />
+      </SidebarProvider>
+    );
+
+    expect(
+      screen
+        .getByRole("link", { name: "Radio Group" })
+        .getAttribute("aria-current")
+    ).toBe("page");
+    expect(
+      screen
+        .getByRole("link", { name: "Accordion" })
+        .getAttribute("aria-current")
+    ).toBeNull();
+  });
+
+  it("centers the newly selected page after client navigation", () => {
+    const view = render(
+      <SidebarProvider>
+        <DocsSidebar tree={tree} />
+      </SidebarProvider>
+    );
+    const viewport = view.container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+
+    expect(viewport?.scrollTop).toBe(415);
+
+    navigation.pathname = "/docs/components/card";
+    view.rerender(
+      <SidebarProvider>
+        <DocsSidebar tree={tree} />
+      </SidebarProvider>
+    );
+
+    expect(viewport?.scrollTop).toBe(115);
+    expect(
+      screen.getByRole("link", { name: "Card" }).getAttribute("aria-current")
+    ).toBe("page");
+    expect(window.scrollY).toBe(0);
+  });
+
+  it("returns to the current top-level section after leaving a component page", () => {
+    const view = render(
+      <SidebarProvider>
+        <DocsSidebar tree={tree} />
+      </SidebarProvider>
+    );
+    const viewport = view.container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+
+    expect(viewport?.scrollTop).toBe(415);
+
+    navigation.pathname = "/docs/components";
+    view.rerender(
+      <SidebarProvider>
+        <DocsSidebar tree={tree} />
+      </SidebarProvider>
+    );
+
+    expect(viewport?.scrollTop).toBe(0);
+    expect(
+      screen
+        .getByRole("link", { name: "Components" })
+        .getAttribute("aria-current")
+    ).toBe("page");
+  });
+
+  it("clamps the first and last pages to the sidebar scroll range", () => {
+    navigation.pathname = "/docs/components/accordion";
+    const view = render(
+      <SidebarProvider>
+        <DocsSidebar tree={tree} />
+      </SidebarProvider>
+    );
+    const viewport = view.container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+
+    expect(viewport?.scrollTop).toBe(0);
+
+    navigation.pathname = "/docs/components/xp-bar";
+    view.rerender(
+      <SidebarProvider>
+        <DocsSidebar tree={tree} />
+      </SidebarProvider>
+    );
+
+    expect(viewport?.scrollTop).toBe(600);
+  });
+
+  it("centers the current page when a hidden sidebar becomes visible", () => {
+    viewportHeight = 0;
+    const view = render(
+      <SidebarProvider>
+        <DocsSidebar tree={tree} />
+      </SidebarProvider>
+    );
+    const viewport = view.container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+
+    expect(viewport?.scrollTop).toBe(0);
+
+    viewportHeight = 400;
+    act(() => resizeCallback?.([], {} as ResizeObserver));
+
+    expect(viewport?.scrollTop).toBe(415);
+  });
+});
+
+describe("BlocksSidebar", () => {
+  it("centers and identifies the current block after a direct load", () => {
+    navigation.pathname = "/docs/blocks/gaming/loading-screen";
+    const view = render(
+      <SidebarProvider>
+        <BlocksSidebar tree={blocksTree} />
+      </SidebarProvider>
+    );
+    const viewport = view.container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    );
+    const activeLink = screen.getByRole("link", { name: "Loading Screen" });
+
+    expect(viewport?.scrollTop).toBe(415);
+    expect(activeLink.getAttribute("aria-current")).toBe("page");
+    expect(window.scrollY).toBe(0);
+  });
+});

--- a/components/docs-sidebar.tsx
+++ b/components/docs-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { TOP_LEVEL_SECTIONS } from "@/config/nav-items";
+import { useCenterActiveSidebarItem } from "@/hooks/use-center-active-sidebar-item";
 import type { source } from "@/lib/source";
 
 import { ScrollArea } from "./ui/scroll-area";
@@ -25,6 +26,7 @@ export function DocsSidebar({
   ...props
 }: React.ComponentProps<typeof Sidebar> & { tree: typeof source.pageTree }) {
   const pathname = usePathname();
+  const { activeItemRef, viewportRef } = useCenterActiveSidebarItem(pathname);
 
   return (
     <Sidebar
@@ -33,7 +35,7 @@ export function DocsSidebar({
       {...props}
     >
       <SidebarContent className="no-scrollbar overflow-x-hidden px-2">
-        <ScrollArea className="h-[calc(90svh-50px)]">
+        <ScrollArea className="h-[calc(90svh-50px)]" viewportRef={viewportRef}>
           <div className="sticky -top-1 z-10 h-8 shrink-0 bg-gradient-to-b from-background via-background/80 to-background/50 blur-xs" />
           <SidebarGroup>
             <SidebarGroupLabel className="font-medium text-muted-foreground">
@@ -41,24 +43,32 @@ export function DocsSidebar({
             </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {TOP_LEVEL_SECTIONS.map(({ name, href }) => (
-                  <SidebarMenuItem key={name}>
-                    <SidebarMenuButton
-                      asChild
-                      className="relative h-[30px] 3xl:fixed:w-full w-fit 3xl:fixed:max-w-48 overflow-visible border border-transparent font-medium text-[0.8rem] after:absolute after:inset-x-0 after:-inset-y-1 after:z-0 after:rounded-md data-[active=true]:border-accent data-[active=true]:bg-accent"
-                      isActive={
-                        href === "/docs"
-                          ? pathname === href
-                          : pathname.startsWith(href)
-                      }
-                    >
-                      <Link href={href}>
-                        <span className="absolute inset-0 flex w-(--sidebar-width) bg-transparent" />
-                        {name}
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))}
+                {TOP_LEVEL_SECTIONS.map(({ name, href }) => {
+                  const isCurrentPage = pathname === href;
+                  const isSectionActive =
+                    href === "/docs"
+                      ? isCurrentPage
+                      : pathname.startsWith(href);
+
+                  return (
+                    <SidebarMenuItem key={name}>
+                      <SidebarMenuButton
+                        asChild
+                        className="relative h-[30px] 3xl:fixed:w-full w-fit 3xl:fixed:max-w-48 overflow-visible border border-transparent font-medium text-[0.8rem] after:absolute after:inset-x-0 after:-inset-y-1 after:z-0 after:rounded-md data-[active=true]:border-accent data-[active=true]:bg-accent"
+                        isActive={isSectionActive}
+                      >
+                        <Link
+                          aria-current={isCurrentPage ? "page" : undefined}
+                          href={href}
+                          ref={isCurrentPage ? activeItemRef : undefined}
+                        >
+                          <span className="absolute inset-0 flex w-(--sidebar-width) bg-transparent" />
+                          {name}
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
@@ -76,29 +86,36 @@ export function DocsSidebar({
                   {item.type === "folder" && (
                     <SidebarMenu className="gap-0.5">
                       {item.children.map((childItem) => {
+                        if (childItem.type !== "page") {
+                          return null;
+                        }
+
                         if (
-                          childItem.type === "page" &&
-                          childItem.url?.includes("/mcp")
+                          childItem.url.includes("/mcp") ||
+                          EXCLUDED_PAGES.includes(childItem.url)
                         ) {
                           return null;
                         }
 
+                        const isActive = childItem.url === pathname;
+
                         return (
-                          childItem.type === "page" &&
-                          !EXCLUDED_PAGES.includes(childItem.url) && (
-                            <SidebarMenuItem key={childItem.url}>
-                              <SidebarMenuButton
-                                asChild
-                                className="relative h-[30px] 3xl:fixed:w-full w-fit 3xl:fixed:max-w-48 overflow-visible border border-transparent font-medium text-[0.8rem] after:absolute after:inset-x-0 after:-inset-y-1 after:z-0 after:rounded-md data-[active=true]:border-accent data-[active=true]:bg-accent"
-                                isActive={childItem.url === pathname}
+                          <SidebarMenuItem key={childItem.url}>
+                            <SidebarMenuButton
+                              asChild
+                              className="relative h-[30px] 3xl:fixed:w-full w-fit 3xl:fixed:max-w-48 overflow-visible border border-transparent font-medium text-[0.8rem] after:absolute after:inset-x-0 after:-inset-y-1 after:z-0 after:rounded-md data-[active=true]:border-accent data-[active=true]:bg-accent"
+                              isActive={isActive}
+                            >
+                              <Link
+                                aria-current={isActive ? "page" : undefined}
+                                href={childItem.url}
+                                ref={isActive ? activeItemRef : undefined}
                               >
-                                <Link href={childItem.url}>
-                                  <span className="absolute inset-0 flex w-(--sidebar-width) bg-transparent" />
-                                  {childItem.name}
-                                </Link>
-                              </SidebarMenuButton>
-                            </SidebarMenuItem>
-                          )
+                                <span className="absolute inset-0 flex w-(--sidebar-width) bg-transparent" />
+                                {childItem.name}
+                              </Link>
+                            </SidebarMenuButton>
+                          </SidebarMenuItem>
                         );
                       })}
                     </SidebarMenu>

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -9,8 +9,11 @@ import { cn } from "@/lib/utils";
 function ScrollArea({
   className,
   children,
+  viewportRef,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
+  viewportRef?: React.Ref<HTMLDivElement>;
+}) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -18,6 +21,7 @@ function ScrollArea({
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
         data-slot="scroll-area-viewport"
         className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >

--- a/hooks/use-center-active-sidebar-item.ts
+++ b/hooks/use-center-active-sidebar-item.ts
@@ -1,0 +1,61 @@
+import { useLayoutEffect, useRef } from "react";
+
+function centerActiveSidebarItem(
+  viewport: HTMLDivElement,
+  activeItem: HTMLAnchorElement
+): boolean {
+  if (viewport.clientHeight === 0) {
+    return false;
+  }
+
+  const viewportRect = viewport.getBoundingClientRect();
+  const activeItemRect = activeItem.getBoundingClientRect();
+  const centeredScrollTop =
+    viewport.scrollTop +
+    activeItemRect.top -
+    viewportRect.top -
+    (viewport.clientHeight - activeItemRect.height) / 2;
+  const maximumScrollTop = Math.max(
+    viewport.scrollHeight - viewport.clientHeight,
+    0
+  );
+
+  viewport.scrollTop = Math.min(
+    Math.max(centeredScrollTop, 0),
+    maximumScrollTop
+  );
+
+  return true;
+}
+
+function useCenterActiveSidebarItem(pathname: string) {
+  const activeItemRef = useRef<HTMLAnchorElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Re-center whenever the active route changes.
+  useLayoutEffect(() => {
+    const activeItem = activeItemRef.current;
+    const viewport = viewportRef.current;
+
+    if (!(activeItem && viewport)) {
+      return;
+    }
+
+    if (centerActiveSidebarItem(viewport, activeItem)) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      if (centerActiveSidebarItem(viewport, activeItem)) {
+        resizeObserver.disconnect();
+      }
+    });
+    resizeObserver.observe(viewport);
+
+    return () => resizeObserver.disconnect();
+  }, [pathname]);
+
+  return { activeItemRef, viewportRef };
+}
+
+export { useCenterActiveSidebarItem };


### PR DESCRIPTION
## Summary

- center the current documentation item inside the nested sidebar viewport on initial load and client-side navigation
- apply the same behavior to component and block documentation, including hidden-mobile-to-desktop resizing and edge clamping
- expose the ScrollArea viewport ref and mark exact matches with `aria-current="page"`
- add regression coverage for refresh, navigation, responsive visibility, bounds, and blocks parity

## Root cause

The route styling highlighted the current item, but the nested Radix ScrollArea viewport had no route-driven scroll restoration. On a hard refresh its `scrollTop` remained at zero, leaving deep items such as Radio Group outside the visible portion of the sidebar.

## User impact

The active documentation page is now centered after refresh and route changes without scrolling the document or moving focus. First and last items clamp to the available sidebar bounds.

## Validation

- `pnpm test` — 139 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm check` — 154 files clean
- `pnpm build`
- Shadscan — 92/100, matching the baseline
- browser QA — two hard refreshes, client navigation, blocks sidebar, 390px → 1280px resize, and first/last clamping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically centers the active documentation or block navigation item when changing pages.
  - Adds accessible active-page indicators to sidebar navigation links.
  - Improves sidebar behavior when opening pages directly or navigating between sections.

- **Bug Fixes**
  - Prevents sidebar scrolling beyond valid boundaries.
  - Improves visibility and positioning when sidebars are resized or initially hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->