### PR TITLE
Remove false related-link skeletons from docs

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -245,15 +245,7 @@ export default async function Page(props: {
                 </p>
               )}
             </div>
-            <Suspense
-              fallback={
-                <div className="flex items-center gap-2 pt-4">
-                  <Skeleton className="h-5 w-16 rounded-full" />
-                  <Skeleton className="h-5 w-16 rounded-full" />
-                  <span className="sr-only">Loading related links</span>
-                </div>
-              }
-            >
+            <Suspense fallback={null}>
               <PageLinks slug={params.slug} />
             </Suspense>
           </div>


### PR DESCRIPTION
## Summary

- stop rendering the two shadcn skeleton pills while optional related links resolve
- preserve the related-links Suspense boundary and real links when a page defines them
- keep legitimate copy-button and MDX loading states unchanged

## Root cause

Every documentation page streamed two visible pill skeletons before `PageLinks` discovered that the page had no related links. On `/docs`, those placeholders flashed and disappeared without representing any eventual content.

## User impact

The Getting Started page no longer flashes two unexplained skeleton pills during initial loading or refresh.

## Validation

- streamed `/docs` HTML: `Loading related links` removed and skeleton nodes reduced from four to two legitimate boundaries
- browser QA: zero related-link placeholders and zero console errors
- `pnpm test` — 139 tests passed
- TypeScript passed
- scoped Ultracite passed
- `pnpm build` passed
- Shadscan — 92/100, matching the enforced baseline; the empty optional-links fallback is an intentional product decision

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated related-link loading behavior to avoid displaying skeleton placeholders while content loads.
  * Removed the loading accessibility label associated with the previous placeholder state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->